### PR TITLE
Fix delegate text answers bug

### DIFF
--- a/app/models/delegation.rb
+++ b/app/models/delegation.rb
@@ -14,7 +14,11 @@ class Delegation < ActiveRecord::Base
   validates :questionnaire_id, presence: true
 
   def can_view_only_assigned_sections?
-    !self.can_view_all_questionnaire? && !self.delegation_sections.empty?
+    !self.can_view_all_questionnaire && !self.delegation_sections.empty?
+  end
+
+  def can_view_and_edit_all_questionnaire?
+    self.delegation_sections.empty?
   end
 
   def available_sections

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -343,6 +343,19 @@ class User < ActiveRecord::Base
     reset_perishable_token!
     UserMailer.deliver_password_reset_instructions(self).deliver
   end
+
+  def can_edit_delegate_text_answer?(section, user_delegate)
+    questionnaire_id = section.questionnaire.id
+    if self.role?(:delegate) && (
+      section.is_delegated?(user_delegate.id) ||
+        user_delegate.delegations.
+          find_by_questionnaire_id_and_user_delegate_id(questionnaire_id, user_delegate.id).
+            try(:can_view_and_edit_all_questionnaire?)
+    )
+      return true
+    end
+    return false
+  end
 end
 
 # == Schema Information

--- a/app/views/text_answers/_delegate_text_answers.html.erb
+++ b/app/views/text_answers/_delegate_text_answers.html.erb
@@ -16,6 +16,9 @@
     <% end %>
   <% end %>
   <% delegate_text_answers.each do |delegate_text_answer| %>
+    <% answer_disabled = answer.question_answered ||
+      !current_user.can_edit_delegate_text_answer?(question.section, @current_user_delegate)
+    %>
     <% unless delegate_answers_div %>
       <div class="delegate-text-answers-wrapper">
       <div class="delegate-text-answers">
@@ -24,7 +27,7 @@
     <div class="delegate-text-answer">
       <% if current_user.id == delegate_text_answer.user_id %>
         <%= hidden_field_tag "delegate_text_answers[#{unique_id}][delegate_answer_id]", delegate_text_answer.id, class: 'disabled_section_information' %>
-        <%= text_area_tag "delegate_text_answers[#{unique_id}][value]", delegate_text_answer.answer_text, :rows => 5, :cols => 68, :readonly => answer.question_answered, :class => ("disabled" if answer.question_answered), style: "float:left;" %>
+        <%= text_area_tag "delegate_text_answers[#{unique_id}][value]", delegate_text_answer.answer_text, :rows => 5, :cols => 68, :readonly => answer_disabled, :class => ("disabled" if answer_disabled), style: "float:left;" %>
       <% else %>
         <%= text_area_tag "other_delegates_answers[#{delegate_text_answer.id}]", delegate_text_answer.answer_text, :rows => 5, :cols => 68, :readonly => true, :class => "disabled", style: "float:left;" %>
         <i class='fa fa-lock'></i>
@@ -37,7 +40,7 @@
     </p>
     </div>
   <% end %>
-<% elsif current_user.is_authorized_to_answer?(question.section, @current_user_delegate)  %>
+<% elsif current_user.can_edit_delegate_text_answer?(question.section, @current_user_delegate) %>
   <div class="delegate-text-answers-wrapper">
   <div class="delegate-text-answers">
   <% delegate_answers_div = true %>


### PR DESCRIPTION
This is to fix two bugs:

- The delegate text answer box was appearing even when `can_view_all_questionnaire` was checked and that section had not been delegated.

- The delegate text answer box was appearing even in the respondent view if the respondent had not answered the question.