### PR TITLE
Add translations for view all questionnaire

### DIFF
--- a/app/views/delegations/edit.html.erb
+++ b/app/views/delegations/edit.html.erb
@@ -29,7 +29,7 @@
 
       <div class="row group padded">
         <%= f.check_box :can_view_all_questionnaire %>
-        <%= f.label :can_view_all_questionnaire, 'When delegate is assigned limited sections, still allow delegate to view (but not edit) entire questionnaire.' %>
+        <%= f.label :can_view_all_questionnaire, t('manage_delegates.can_view_all_questionnaire')  %>
       </div>
 
       <%= f.submit %>

--- a/app/views/delegations/new.html.erb
+++ b/app/views/delegations/new.html.erb
@@ -32,7 +32,7 @@
         </div>
         <div class="row group padded">
           <%= f.check_box :can_view_all_questionnaire %>
-          <%= f.label :can_view_all_questionnaire, 'When delegate is assigned limited sections, still allow delegate to view (but not edit) entire questionnaire.' %>
+          <%= f.label :can_view_all_questionnaire, t('manage_delegates.can_view_all_questionnaire')  %>
         </div>
         <p id="submit_p"><%= f.submit t('generic.delegate') %></p>
       </fieldset>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -136,6 +136,7 @@ en:
     delegations_show_sl: "Delegated sections"
     help_line: "<p>A delegate is a user that can help you fill your questionnaires. A delegate can be assigned with all the sections of your questionnaires or a subset of sections.You can add a delegate by clicking on the 'Add delegate' button.</p><p>For each of your delegates, listed in the table below, you have two available options: <strong>Show</strong>, and <strong>Remove</strong>. The <strong>Remove</strong> option will remove that delegate and all the delegations that were associated with it. The <strong>Show</strong> option will take you to a page with the details of the delegate, including the questionnaires that you have delegated it to.<p/><p>You can associate a delegate with a questionnaire directly from the questionnaire's submission page. Bare in mind that not all questionnaires have the delegation feature enabled.</p>"
     delegate_show_help: "You will be able to answer questionnaires on his behalf. See below a list of the questionnaires that you are authorised to answer."
+    can_view_all_questionnaire: "When delegate is assigned limited sections, still allow delegate to view (but not edit) entire questionnaire."
   flash_messages:
     nothing_to_save: "Nothing to save"
     saved_successfully: "answers were successfully saved"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -130,6 +130,7 @@ es:
     delegations_show_sl: "Apartados delegados"
     help_line: "<p>Un delegado es un usuario que puede colaborar con usted en la cumplimentación de los cuestionarios. Puede asignarle todos los apartados de los cuestionarios o un subconjunto de apartados. Si desea añadir un delegado, pulse en “Añadir delegado”.</p><p>Para cada uno de sus delegados, enumerados en el cuadro siguiente, dispone de dos opciones <strong>Mostrar</strong> y <strong>Eliminar</strong>. La opción <strong>Eliminar</strong> eliminará al delegado y todas las delegaciones que se le habían asignado. La opción <strong>Mostrar</strong> le dirigirá a una página en la que encontrará todos los datos del delegado, incluidos los cuestionarios que le ha asignado. <p/><p>Puede asignar un cuestionario a un delegado directamente desde la página de presentación de cuestionarios. No obstante, tenga en cuenta que no todos los cuestionarios tienen activada la opción de delegación.</p>"
     delegate_show_help: "Podrá responder cuestionarios en nombre del encuestado responsable. A continuación puede ver una lista de los cuestionarios que está autorizado a responder."
+    can_view_all_questionnaire: "Al delegar secciones limitadas, todavía se permite ver (pero no editar) todo el cuestionario."
   flash_messages:
     nothing_to_save: "No hay nada para guardar"
     saved_successfully: "las respuestas se han guardado correctamente"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -131,6 +131,7 @@ fr:
     delegations_show_sl: "Sections déléguées"
     help_line: "<p>Un délégué est un utilisateur qui peut vous aider à répondre à vos questionnaires. Vous pouvez lui attribuer toutes les sections de vos questionnaires ou un ensemble de sections. Pour ajouter un délégué, cliquez sur le bouton 'Ajouter un délégué'.</p><p>Pour chacun de vos délégués répertoriés dans le tableau ci-dessous, deux options sont disponibles <strong>Afficher</strong> et <strong>Supprimer</strong>. L'option <strong>Supprimer</strong> supprimera ce délégué et toutes les délégations associées à ce délégué. L'option <strong>Afficher</strong> affichera une page comprenant les informations sur le délégué, dont les questionnaires que vous lui avez délégués.<p/><p>Vous pouvez associer un délégué à un questionnaire directement à partir de la page de soumission du questionnaire. Notez que la fonction de délégation n'est pas activée pour tous les questionnaires.</p>"
     delegate_show_help: "Vous pourrez répondre à des questionnaires à sa place. La liste ci-dessous répertorie les questionnaires auxquels vous êtes autorisé à répondre."
+    can_view_all_questionnaire: "Lorsqu’un délégué est assigné à des sections limitées, veillez à bien lui donner un accès de type lecture (et non édition) à l’intégralité du questionnaire."
   flash_messages:
     nothing_to_save: "Rien à enregistrer"
     saved_successfully: "réponses enregistrées"


### PR DESCRIPTION
This adds translations for the `can_view_all_questionnaire` explanation wording.