### PR TITLE
Add translations for application profile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,8 @@ gem 'rails-secrets'
 
 gem 'appsignal'
 
+gem 'traco'
+
 # Gems used only for assets and not required
 # in production environments by default.
 group :assets do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,6 +313,8 @@ GEM
     tinymce-rails-langs (4.20140129)
       tinymce-rails (~> 4.0)
     tooltipster-rails (3.2.6)
+    traco (3.1.6)
+      activerecord (>= 3.0)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
@@ -386,6 +388,7 @@ DEPENDENCIES
   tinymce-rails (= 4.0)
   tinymce-rails-langs (~> 4.2)
   tooltipster-rails (~> 3.2.6)
+  traco
   uglifier
 
 BUNDLED WITH

--- a/app/models/application_profile.rb
+++ b/app/models/application_profile.rb
@@ -17,8 +17,8 @@
 
 class ApplicationProfile < ActiveRecord::Base
 
-  attr_accessible :title, :short_title, :sub_title, :logo, :logo_url, :show_sign_up
-
+  attr_accessible :title, :title_en, :title_fr, :title_es, :short_title, :sub_title, :logo, :logo_url, :show_sign_up
+  translates :title
   # The # symbol after the size will scale and crop to exactly that size
   has_attached_file :logo, :styles => { :small => 'x55' }, :default_url => "/images/:style/missing.png"
   validates_attachment :logo, :size => { :in => 0..2.megabytes, :message => "The file's size must be less than 2MB"}

--- a/app/views/application_profile/index.html.erb
+++ b/app/views/application_profile/index.html.erb
@@ -4,8 +4,16 @@
 
   <fieldset>
     <div class="row padded group" >
-      <%= f.label :title %>
-      <%= f.text_field :title %>
+      <%= f.label :title_en, "English Title" %>
+      <%= f.text_field :title_en %>
+    </div>
+    <div class="row padded group" >
+      <%= f.label :title_fr, "French Title" %>
+      <%= f.text_field :title_fr %>
+    </div>
+    <div class="row padded group" >
+      <%= f.label :title_es, "Spanish Title" %>
+      <%= f.text_field :title_es %>
     </div>
     <div class="row padded group" >
       <%= f.label :short_title %>

--- a/db/migrate/20160928090747_add_title_translations_in_application_profile.rb
+++ b/db/migrate/20160928090747_add_title_translations_in_application_profile.rb
@@ -1,0 +1,13 @@
+class AddTitleTranslationsInApplicationProfile < ActiveRecord::Migration
+  def up
+    rename_column :application_profiles, :title, :title_en
+    add_column :application_profiles, :title_fr, :string, default: ''
+    add_column :application_profiles, :title_es, :string, default: ''
+  end
+
+  def down
+    rename_column :application_profiles, :title_en, :title
+    remove_column :application_profiles, :title_fr
+    remove_column :application_profiles, :title_es
+  end
+end


### PR DESCRIPTION
Adds english, french, and spanish translations for the `title` attribute in `ApplicationProfile`. So, accessing the `/application_profile` page is possible to specify different translations for the title and then it will be displayed according to the current locale.