### PR TITLE
Accept delegate text answer

### DIFF
--- a/app/assets/javascripts/respondent/accept_answer.js
+++ b/app/assets/javascripts/respondent/accept_answer.js
@@ -1,0 +1,8 @@
+$(document).ready(function() {
+  $(document).on('click', '.accept-btn', function(e) {
+    e.preventDefault();
+    answer = $(this).closest('.delegate-text-answer').find('textarea').val();
+    text_answer = $(this).closest('.answer_fields_wrapper').find('.text-answer')
+    $(text_answer).find('textarea').val(answer);
+  });
+});

--- a/app/assets/stylesheets/respondent/style.scss
+++ b/app/assets/stylesheets/respondent/style.scss
@@ -94,9 +94,22 @@ input[type='checkbox'] { margin: 0 5px 0 0; }
     vertical-align: middle;
     .delegate-text-answer {
       width: 690px;
-      height: 160px;
+      height: 180px;
       border-right: 8px $grey-10 solid;
     }
+  }
+}
+
+.delegate-answer-details {
+  width: 640px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  .tooltips, .accept-btn-container {
+    display: inline-block;
+  }
+  .accept-btn-container {
+    margin-left: 100px;
   }
 }
 

--- a/app/views/text_answers/_delegate_text_answers.html.erb
+++ b/app/views/text_answers/_delegate_text_answers.html.erb
@@ -34,8 +34,8 @@
           <i class='fa fa-lock'></i>
         <% end %>
       </div>
-      <div class="delegate-answer-details">
-        <div class="tooltips">
+      <div class="delegate-answer-details row">
+        <div class="tooltips col-9">
           Answered by:
           <% editor = delegate_text_answer.user %>
           <span><%= editor.id != current_user.id ? (link_to h(editor.full_name)[0,30], user_path(editor), :title => h(editor.full_name)) : 'You' -%></span>
@@ -43,7 +43,7 @@
         </div>
         <% if current_user.role?(:respondent) &&
              current_user.authorized_submitter_of?(question.questionnaire) %>
-          <div class="accept-btn-container">
+          <div class="accept-btn-container col-3">
             <%= link_to 'Accept answer', '#', class: 'btn accept-btn' %>
           </div>
         <% end %>

--- a/app/views/text_answers/_delegate_text_answers.html.erb
+++ b/app/views/text_answers/_delegate_text_answers.html.erb
@@ -25,19 +25,26 @@
       <% delegate_answers_div = true %>
     <% end %>
     <div class="delegate-text-answer">
-      <% if current_user.id == delegate_text_answer.user_id %>
-        <%= hidden_field_tag "delegate_text_answers[#{unique_id}][delegate_answer_id]", delegate_text_answer.id, class: 'disabled_section_information' %>
-        <%= text_area_tag "delegate_text_answers[#{unique_id}][value]", delegate_text_answer.answer_text, :rows => 5, :cols => 68, :readonly => answer_disabled, :class => ("disabled" if answer_disabled), style: "float:left;" %>
-      <% else %>
-        <%= text_area_tag "other_delegates_answers[#{delegate_text_answer.id}]", delegate_text_answer.answer_text, :rows => 5, :cols => 68, :readonly => true, :class => "disabled", style: "float:left;" %>
-        <i class='fa fa-lock'></i>
-      <% end %>
-    <p class="tooltips" style="float:left; clear:both;">
-      Answered by:
-      <% editor = delegate_text_answer.user %>
-      <span><%= editor.id != current_user.id ? (link_to h(editor.full_name)[0,30], user_path(editor), :title => h(editor.full_name)) : 'You' -%></span>
-      <span>(<%= delegate_text_answer.updated_at %>)</span>
-    </p>
+      <div class="delegate-text-area">
+        <% if current_user.id == delegate_text_answer.user_id %>
+          <%= hidden_field_tag "delegate_text_answers[#{unique_id}][delegate_answer_id]", delegate_text_answer.id, class: 'disabled_section_information' %>
+          <%= text_area_tag "delegate_text_answers[#{unique_id}][value]", delegate_text_answer.answer_text, :rows => 5, :cols => 68, :readonly => answer_disabled, :class => ("disabled" if answer_disabled), style: "float:left;" %>
+        <% else %>
+          <%= text_area_tag "other_delegates_answers[#{delegate_text_answer.id}]", delegate_text_answer.answer_text, :rows => 5, :cols => 68, :readonly => true, :class => "disabled", style: "float:left;" %>
+          <i class='fa fa-lock'></i>
+        <% end %>
+      </div>
+      <div class="delegate-answer-details">
+        <div class="tooltips">
+          Answered by:
+          <% editor = delegate_text_answer.user %>
+          <span><%= editor.id != current_user.id ? (link_to h(editor.full_name)[0,30], user_path(editor), :title => h(editor.full_name)) : 'You' -%></span>
+          <span>(<%= delegate_text_answer.updated_at %>)</span>
+        </div>
+        <div class="accept-btn-container">
+          <%= link_to 'Accept answer', '#', class: 'btn accept-btn' %>
+        </div>
+      </div>
     </div>
   <% end %>
 <% elsif current_user.can_edit_delegate_text_answer?(question.section, @current_user_delegate) %>

--- a/app/views/text_answers/_delegate_text_answers.html.erb
+++ b/app/views/text_answers/_delegate_text_answers.html.erb
@@ -41,9 +41,12 @@
           <span><%= editor.id != current_user.id ? (link_to h(editor.full_name)[0,30], user_path(editor), :title => h(editor.full_name)) : 'You' -%></span>
           <span>(<%= delegate_text_answer.updated_at %>)</span>
         </div>
-        <div class="accept-btn-container">
-          <%= link_to 'Accept answer', '#', class: 'btn accept-btn' %>
-        </div>
+        <% if current_user.role?(:respondent) &&
+             current_user.authorized_submitter_of?(question.questionnaire) %>
+          <div class="accept-btn-container">
+            <%= link_to 'Accept answer', '#', class: 'btn accept-btn' %>
+          </div>
+        <% end %>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
Adds a button at the bottom of a delegate text answer in order to easily copy the value inside the respondent answer.