### PR TITLE
Amend old migrations

### DIFF
--- a/db/migrate/20150428213052_add_constraints_to_matrix_answer_drop_option_fields.rb
+++ b/db/migrate/20150428213052_add_constraints_to_matrix_answer_drop_option_fields.rb
@@ -5,9 +5,11 @@ class AddConstraintsToMatrixAnswerDropOptionFields < ActiveRecord::Migration
       name: 'index_matrix_answer_drop_option_fields_on_drop_option_id'
     execute <<-SQL
       DELETE FROM matrix_answer_drop_option_fields
-      WHERE matrix_answer_drop_option_id IS NULL
-      OR matrix_answer_drop_option_id NOT IN (
-        SELECT id FROM matrix_answer_drop_options
+      WHERE id IN (
+        SELECT madof.id
+        FROM matrix_answer_drop_option_fields AS madof
+        LEFT OUTER JOIN matrix_answer_drop_options AS mado ON madof.matrix_answer_drop_option_id = mado.id
+        WHERE mado.id IS NULL OR madof.matrix_answer_drop_option_id IS NULL
       )
     SQL
 

--- a/db/migrate/20150428215312_add_constraints_to_matrix_answer_option_fields.rb
+++ b/db/migrate/20150428215312_add_constraints_to_matrix_answer_option_fields.rb
@@ -4,9 +4,11 @@ class AddConstraintsToMatrixAnswerOptionFields < ActiveRecord::Migration
     add_index :matrix_answer_option_fields, :matrix_answer_option_id
     execute <<-SQL
       DELETE FROM matrix_answer_option_fields
-      WHERE matrix_answer_option_id IS NULL
-      OR matrix_answer_option_id NOT IN (
-        SELECT id FROM matrix_answer_options
+      WHERE id IN (
+        SELECT maof.id
+        FROM matrix_answer_option_fields AS maof
+        LEFT OUTER JOIN matrix_answer_options AS mao ON maof.matrix_answer_option_id = mao.id
+        WHERE mao.id IS NULL OR maof.matrix_answer_option_id IS NULL
       )
     SQL
 

--- a/db/migrate/20150428221632_add_constraints_to_matrix_answer_query_fields.rb
+++ b/db/migrate/20150428221632_add_constraints_to_matrix_answer_query_fields.rb
@@ -4,9 +4,11 @@ class AddConstraintsToMatrixAnswerQueryFields < ActiveRecord::Migration
     add_index :matrix_answer_query_fields, :matrix_answer_query_id
     execute <<-SQL
       DELETE FROM matrix_answer_query_fields
-      WHERE matrix_answer_query_id IS NULL
-      OR matrix_answer_query_id NOT IN (
-        SELECT id FROM matrix_answer_queries
+      WHERE id IN (
+        SELECT maqf.id
+        FROM matrix_answer_query_fields AS maqf
+        LEFT OUTER JOIN matrix_answer_queries AS maq ON maqf.matrix_answer_query_id = maq.id
+        WHERE maq.id IS NULL OR maqf.matrix_answer_query_id IS NULL
       )
     SQL
 

--- a/db/migrate/20150428223139_add_constraints_to_matrix_answer_options.rb
+++ b/db/migrate/20150428223139_add_constraints_to_matrix_answer_options.rb
@@ -4,9 +4,11 @@ class AddConstraintsToMatrixAnswerOptions < ActiveRecord::Migration
     add_index :matrix_answer_options, :matrix_answer_id
     execute <<-SQL
       DELETE FROM matrix_answer_options
-      WHERE matrix_answer_id IS NULL
-      OR matrix_answer_id NOT IN (
-        SELECT id FROM matrix_answers
+      WHERE id IN (
+        SELECT mao.id
+        FROM matrix_answer_options AS mao
+        LEFT OUTER JOIN matrix_answers AS ma ON mao.matrix_answer_id = ma.id
+        WHERE ma.id IS NULL OR mao.matrix_answer_id IS NULL
       )
     SQL
 

--- a/db/migrate/20150428223357_add_constraints_to_matrix_answer_queries.rb
+++ b/db/migrate/20150428223357_add_constraints_to_matrix_answer_queries.rb
@@ -4,9 +4,11 @@ class AddConstraintsToMatrixAnswerQueries < ActiveRecord::Migration
     add_index :matrix_answer_queries, :matrix_answer_id
     execute <<-SQL
       DELETE FROM matrix_answer_queries
-      WHERE matrix_answer_id IS NULL
-      OR matrix_answer_id NOT IN (
-        SELECT id FROM matrix_answers
+      WHERE id IN (
+        SELECT maq.id
+        FROM matrix_answer_queries AS maq
+        LEFT OUTER JOIN matrix_answers AS ma ON maq.matrix_answer_id = ma.id
+        WHERE ma.id IS NULL OR maq.matrix_answer_id IS NULL
       )
     SQL
 

--- a/db/migrate/20150430123243_add_constraints_to_multi_answer_option_fields.rb
+++ b/db/migrate/20150430123243_add_constraints_to_multi_answer_option_fields.rb
@@ -1,5 +1,11 @@
 class AddConstraintsToMultiAnswerOptionFields < ActiveRecord::Migration
   def up
+    # if API views already in place, need to drop before changing columns
+    if ActiveRecord::Base.connection.table_exists? 'api_multi_answer_options_view'
+      drop_view_and_dependent_views
+      re_create_view = true
+    end
+
     # make multi_answer_option_id NOT NULL & add foreign key constraint
     add_index :multi_answer_option_fields, :multi_answer_option_id
     execute <<-SQL
@@ -35,10 +41,20 @@ class AddConstraintsToMultiAnswerOptionFields < ActiveRecord::Migration
     change_column :multi_answer_option_fields, :created_at, :datetime, null: false
     execute "UPDATE multi_answer_option_fields SET updated_at = NOW() WHERE updated_at IS NULL"
     change_column :multi_answer_option_fields, :updated_at, :datetime, null: false
+
+    # re-create the view if necessary
+    create_view_and_dependent_views if re_create_view
   end
 
   def down
+    # if API views already in place, need to drop before changing columns
+    if ActiveRecord::Base.connection.table_exists? 'api_multi_answer_options_view'
+      drop_view_and_dependent_views
+      re_create_view = true
+    end
+
     remove_index :multi_answer_option_fields, :multi_answer_option_id
+
     change_column :multi_answer_option_fields,
       :multi_answer_option_id, :integer, null: true
     remove_foreign_key :multi_answer_option_fields, column: :multi_answer_option_id
@@ -53,5 +69,20 @@ class AddConstraintsToMultiAnswerOptionFields < ActiveRecord::Migration
       :created_at, :datetime, null: true
     change_column :multi_answer_option_fields,
       :updated_at, :datetime, null: true
+
+    # create the view if necessary
+    create_view_and_dependent_views if re_create_view
+  end
+
+  def drop_view_and_dependent_views
+    execute 'DROP VIEW api_answers_view'
+    execute 'DROP VIEW api_questions_tree_view'
+    execute 'DROP VIEW api_multi_answer_options_view'
+  end
+
+  def create_view_and_dependent_views
+    execute view_sql('20151030151237', 'api_multi_answer_options_view')
+    execute view_sql('20160202174508', 'api_questions_tree_view')
+    execute view_sql('20160203162148', 'api_answers_view')
   end
 end

--- a/db/migrate/20150430123243_add_constraints_to_multi_answer_option_fields.rb
+++ b/db/migrate/20150430123243_add_constraints_to_multi_answer_option_fields.rb
@@ -4,9 +4,11 @@ class AddConstraintsToMultiAnswerOptionFields < ActiveRecord::Migration
     add_index :multi_answer_option_fields, :multi_answer_option_id
     execute <<-SQL
       DELETE FROM multi_answer_option_fields
-      WHERE multi_answer_option_id IS NULL
-      OR multi_answer_option_id NOT IN (
-        SELECT id FROM multi_answer_options
+      WHERE id IN (
+        SELECT maof.id
+        FROM multi_answer_option_fields AS maof
+        LEFT OUTER JOIN multi_answer_options AS mao ON maof.multi_answer_option_id = mao.id
+        WHERE mao.id IS NULL OR maof.multi_answer_option_id IS NULL
       )
     SQL
 

--- a/db/migrate/20150430124107_add_constraints_to_multi_answer_options.rb
+++ b/db/migrate/20150430124107_add_constraints_to_multi_answer_options.rb
@@ -4,9 +4,11 @@ class AddConstraintsToMultiAnswerOptions < ActiveRecord::Migration
     add_index :multi_answer_options, :multi_answer_id
     execute <<-SQL
       DELETE FROM multi_answer_options
-      WHERE multi_answer_id IS NULL
-      OR multi_answer_id NOT IN (
-        SELECT id FROM multi_answers
+      WHERE id IN (
+        SELECT mao.id
+        FROM multi_answer_options AS mao
+        LEFT OUTER JOIN multi_answers AS ma ON mao.multi_answer_id = ma.id
+        WHERE ma.id IS NULL OR mao.multi_answer_id IS NULL
       )
     SQL
 

--- a/db/migrate/20150430124107_add_constraints_to_multi_answer_options.rb
+++ b/db/migrate/20150430124107_add_constraints_to_multi_answer_options.rb
@@ -1,5 +1,11 @@
 class AddConstraintsToMultiAnswerOptions < ActiveRecord::Migration
   def up
+    # if API views already in place, need to drop before changing columns
+    if ActiveRecord::Base.connection.table_exists? 'api_multi_answer_options_view'
+      drop_view_and_dependent_views
+      re_create_view = true
+    end
+
     # make multi_answer_id NOT NULL & add foreign key constraint
     add_index :multi_answer_options, :multi_answer_id
     execute <<-SQL
@@ -25,9 +31,18 @@ class AddConstraintsToMultiAnswerOptions < ActiveRecord::Migration
     change_column :multi_answer_options, :created_at, :datetime, null: false
     execute "UPDATE multi_answer_options SET updated_at = NOW() WHERE updated_at IS NULL"
     change_column :multi_answer_options, :updated_at, :datetime, null: false
+
+    # re-create the view if necessary
+    create_view_and_dependent_views if re_create_view
   end
 
   def down
+    # if API views already in place, need to drop before changing columns
+    if ActiveRecord::Base.connection.table_exists? 'api_multi_answer_options_view'
+      drop_view_and_dependent_views
+      re_create_view = true
+    end
+
     remove_index :multi_answer_options, :multi_answer_id
     change_column :multi_answer_options,
       :multi_answer_id, :integer, null: true
@@ -37,5 +52,20 @@ class AddConstraintsToMultiAnswerOptions < ActiveRecord::Migration
       :created_at, :datetime, null: true
     change_column :multi_answer_options,
       :updated_at, :datetime, null: true
+
+    # re-create the view if necessary
+    create_view_and_dependent_views if re_create_view
+  end
+
+  def drop_view_and_dependent_views
+    execute 'DROP VIEW api_answers_view'
+    execute 'DROP VIEW api_questions_tree_view'
+    execute 'DROP VIEW api_multi_answer_options_view'
+  end
+
+  def create_view_and_dependent_views
+    execute view_sql('20151030151237', 'api_multi_answer_options_view')
+    execute view_sql('20160202174508', 'api_questions_tree_view')
+    execute view_sql('20160203162148', 'api_answers_view')
   end
 end

--- a/db/migrate/20150430203801_add_constraints_to_other_fields.rb
+++ b/db/migrate/20150430203801_add_constraints_to_other_fields.rb
@@ -4,9 +4,11 @@ class AddConstraintsToOtherFields < ActiveRecord::Migration
     add_index :other_fields, :multi_answer_id
     execute <<-SQL
       DELETE FROM other_fields
-      WHERE multi_answer_id IS NULL
-      OR multi_answer_id NOT IN (
-        SELECT id FROM multi_answers
+      WHERE id IN (
+        SELECT of.id
+        FROM other_fields AS of
+        LEFT OUTER JOIN multi_answers AS ma ON of.multi_answer_id = ma.id
+        WHERE ma.id IS NULL OR of.multi_answer_id IS NULL
       )
     SQL
 

--- a/db/migrate/20150430211200_add_constraints_to_range_answer_option_fields.rb
+++ b/db/migrate/20150430211200_add_constraints_to_range_answer_option_fields.rb
@@ -1,5 +1,11 @@
 class AddConstraintsToRangeAnswerOptionFields < ActiveRecord::Migration
   def up
+    # if API views already in place, need to drop before changing columns
+    if ActiveRecord::Base.connection.table_exists? 'api_range_answer_options_view'
+      drop_view_and_dependent_views
+      re_create_view = true
+    end
+
     # make range_answer_option_id NOT NULL & add foreign key constraint
     add_index :range_answer_option_fields, :range_answer_option_id
     execute <<-SQL
@@ -35,9 +41,18 @@ class AddConstraintsToRangeAnswerOptionFields < ActiveRecord::Migration
     change_column :range_answer_option_fields, :created_at, :datetime, null: false
     execute "UPDATE range_answer_option_fields SET updated_at = NOW() WHERE updated_at IS NULL"
     change_column :range_answer_option_fields, :updated_at, :datetime, null: false
+
+    # re-create the view if necessary
+    create_view_and_dependent_views if re_create_view
   end
 
   def down
+    # if API views already in place, need to drop before changing columns
+    if ActiveRecord::Base.connection.table_exists? 'api_range_answer_options_view'
+      drop_view_and_dependent_views
+      re_create_view = true
+    end
+
     remove_index :range_answer_option_fields, :range_answer_option_id
     change_column :range_answer_option_fields,
       :range_answer_option_id, :integer, null: true
@@ -53,6 +68,20 @@ class AddConstraintsToRangeAnswerOptionFields < ActiveRecord::Migration
       :created_at, :datetime, null: true
     change_column :range_answer_option_fields,
       :updated_at, :datetime, null: true
+
+    # re-create the view if necessary
+    create_view_and_dependent_views if re_create_view
   end
 
+  def drop_view_and_dependent_views
+    execute 'DROP VIEW api_answers_view'
+    execute 'DROP VIEW api_questions_tree_view'
+    execute 'DROP VIEW api_range_answer_options_view'
+  end
+
+  def create_view_and_dependent_views
+    execute view_sql('20151030151237', 'api_range_answer_options_view')
+    execute view_sql('20160202174508', 'api_questions_tree_view')
+    execute view_sql('20160203162148', 'api_answers_view')
+  end
 end

--- a/db/migrate/20150430211200_add_constraints_to_range_answer_option_fields.rb
+++ b/db/migrate/20150430211200_add_constraints_to_range_answer_option_fields.rb
@@ -4,9 +4,11 @@ class AddConstraintsToRangeAnswerOptionFields < ActiveRecord::Migration
     add_index :range_answer_option_fields, :range_answer_option_id
     execute <<-SQL
       DELETE FROM range_answer_option_fields
-      WHERE range_answer_option_id IS NULL
-      OR range_answer_option_id NOT IN (
-        SELECT id FROM range_answer_options
+      WHERE id IN (
+        SELECT raof.id
+        FROM range_answer_option_fields AS raof
+        LEFT OUTER JOIN range_answer_options AS rao ON raof.range_answer_option_id = rao.id
+        WHERE rao.id IS NULL OR raof.range_answer_option_id IS NULL
       )
     SQL
 

--- a/db/migrate/20150430211732_add_constraints_to_range_answer_options.rb
+++ b/db/migrate/20150430211732_add_constraints_to_range_answer_options.rb
@@ -4,9 +4,11 @@ class AddConstraintsToRangeAnswerOptions < ActiveRecord::Migration
     add_index :range_answer_options, :range_answer_id
     execute <<-SQL
       DELETE FROM range_answer_options
-      WHERE range_answer_id IS NULL
-      OR range_answer_id NOT IN (
-        SELECT id FROM range_answers
+      WHERE id IN (
+        SELECT rao.id
+        FROM range_answer_options AS rao
+        LEFT OUTER JOIN range_answers AS ra ON rao.range_answer_id = ra.id
+        WHERE ra.id IS NULL OR rao.range_answer_id IS NULL
       )
     SQL
 

--- a/db/migrate/20150430211732_add_constraints_to_range_answer_options.rb
+++ b/db/migrate/20150430211732_add_constraints_to_range_answer_options.rb
@@ -1,5 +1,11 @@
 class AddConstraintsToRangeAnswerOptions < ActiveRecord::Migration
   def up
+    # if API views already in place, need to drop before changing columns
+    if ActiveRecord::Base.connection.table_exists? 'api_range_answer_options_view'
+      drop_view_and_dependent_views
+      re_create_view = true
+    end
+
     # make range_answer_id NOT NULL & add foreign key constraint
     add_index :range_answer_options, :range_answer_id
     execute <<-SQL
@@ -39,9 +45,18 @@ class AddConstraintsToRangeAnswerOptions < ActiveRecord::Migration
     change_column :range_answer_options, :created_at, :datetime, null: false
     execute "UPDATE range_answer_options SET updated_at = NOW() WHERE updated_at IS NULL"
     change_column :range_answer_options, :updated_at, :datetime, null: false
+
+    # re-create the view if necessary
+    create_view_and_dependent_views if re_create_view
   end
 
   def down
+    # if API views already in place, need to drop before changing columns
+    if ActiveRecord::Base.connection.table_exists? 'api_range_answer_options_view'
+      drop_view_and_dependent_views
+      re_create_view = true
+    end
+
     remove_index :range_answer_options, :range_answer_id
     change_column :range_answer_options,
       :range_answer_id, :integer, null: true
@@ -53,5 +68,20 @@ class AddConstraintsToRangeAnswerOptions < ActiveRecord::Migration
       :created_at, :datetime, null: true
     change_column :range_answer_options,
       :updated_at, :datetime, null: true
+
+    # re-create the view if necessary
+    create_view_and_dependent_views if re_create_view
+  end
+
+  def drop_view_and_dependent_views
+    execute 'DROP VIEW api_answers_view'
+    execute 'DROP VIEW api_questions_tree_view'
+    execute 'DROP VIEW api_range_answer_options_view'
+  end
+
+  def create_view_and_dependent_views
+    execute view_sql('20151030151237', 'api_range_answer_options_view')
+    execute view_sql('20160202174508', 'api_questions_tree_view')
+    execute view_sql('20160203162148', 'api_answers_view')
   end
 end

--- a/db/migrate/20150501101439_add_constraints_to_rank_answer_option_fields.rb
+++ b/db/migrate/20150501101439_add_constraints_to_rank_answer_option_fields.rb
@@ -4,9 +4,11 @@ class AddConstraintsToRankAnswerOptionFields < ActiveRecord::Migration
     add_index :rank_answer_option_fields, :rank_answer_option_id
     execute <<-SQL
       DELETE FROM rank_answer_option_fields
-      WHERE rank_answer_option_id IS NULL
-      OR rank_answer_option_id NOT IN (
-        SELECT id FROM rank_answer_options
+      WHERE id IN (
+        SELECT raof.id
+        FROM rank_answer_option_fields AS raof
+        LEFT OUTER JOIN rank_answer_options AS rao ON raof.rank_answer_option_id = rao.id
+        WHERE rao.id IS NULL OR raof.rank_answer_option_id IS NULL
       )
     SQL
 

--- a/db/migrate/20150501124910_add_constraints_to_text_answer_fields.rb
+++ b/db/migrate/20150501124910_add_constraints_to_text_answer_fields.rb
@@ -4,9 +4,11 @@ class AddConstraintsToTextAnswerFields < ActiveRecord::Migration
     add_index :text_answer_fields, :text_answer_id
     execute <<-SQL
       DELETE FROM text_answer_fields
-      WHERE text_answer_id IS NULL
-      OR text_answer_id NOT IN (
-        SELECT id FROM text_answers
+      WHERE id IN (
+        SELECT taf.id
+        FROM text_answer_fields AS taf
+        LEFT OUTER JOIN text_answers AS ta ON taf.text_answer_id = ta.id
+        WHERE ta.id IS NULL OR taf.text_answer_id IS NULL
       )
     SQL
 

--- a/db/migrate/20150505083433_add_constraints_to_delegate_text_answers.rb
+++ b/db/migrate/20150505083433_add_constraints_to_delegate_text_answers.rb
@@ -4,9 +4,11 @@ class AddConstraintsToDelegateTextAnswers < ActiveRecord::Migration
     add_index :delegate_text_answers, :answer_id
     execute <<-SQL
       DELETE FROM delegate_text_answers
-      WHERE answer_id IS NULL
-      OR answer_id NOT IN (
-        SELECT id FROM answers
+      WHERE id IN (
+        SELECT dta.id
+        FROM delegate_text_answers AS dta
+        LEFT OUTER JOIN answers AS a ON dta.answer_id = a.id
+        WHERE a.id IS NULL OR dta.answer_id IS NULL
       )
     SQL
 

--- a/db/migrate/20150505091704_add_constraints_to_loop_sources.rb
+++ b/db/migrate/20150505091704_add_constraints_to_loop_sources.rb
@@ -4,9 +4,11 @@ class AddConstraintsToLoopSources < ActiveRecord::Migration
     add_index :loop_sources, :questionnaire_id
     execute <<-SQL
       DELETE FROM loop_sources
-      WHERE questionnaire_id IS NULL
-      OR questionnaire_id NOT IN (
-        SELECT id FROM questionnaires
+      WHERE id IN (
+        SELECT ls.id
+        FROM loop_sources AS ls
+        LEFT OUTER JOIN questionnaires AS q ON ls.questionnaire_id = q.id
+        WHERE q.id IS NULL OR ls.questionnaire_id IS NULL
       )
     SQL
 

--- a/db/migrate/20150505093251_add_constraints_to_filtering_fields.rb
+++ b/db/migrate/20150505093251_add_constraints_to_filtering_fields.rb
@@ -4,9 +4,11 @@ class AddConstraintsToFilteringFields < ActiveRecord::Migration
     add_index :filtering_fields, :questionnaire_id
     execute <<-SQL
       DELETE FROM filtering_fields
-      WHERE questionnaire_id IS NULL
-      OR questionnaire_id NOT IN (
-        SELECT id FROM questionnaires
+      WHERE id IN (
+        SELECT ff.id
+        FROM filtering_fields AS ff
+        LEFT OUTER JOIN questionnaires AS q ON ff.questionnaire_id = q.id
+        WHERE q.id IS NULL OR ff.questionnaire_id IS NULL
       )
     SQL
 

--- a/db/migrate/20150505094630_add_constraints_to_loop_item_types.rb
+++ b/db/migrate/20150505094630_add_constraints_to_loop_item_types.rb
@@ -4,9 +4,11 @@ class AddConstraintsToLoopItemTypes < ActiveRecord::Migration
     # index on parent_id already in place
     execute <<-SQL
       DELETE FROM loop_item_types
-      WHERE parent_id IS NOT NULL
-      AND parent_id NOT IN (
-        SELECT id FROM loop_item_types
+      WHERE id IN (
+        SELECT lit.id
+        FROM loop_item_types AS lit
+        LEFT OUTER JOIN loop_item_types AS lit2 ON lit.parent_id = lit2.id
+        WHERE lit2.id IS NULL AND lit.parent_id IS NOT NULL
       )
     SQL
 

--- a/db/migrate/20150505103111_add_constraints_to_loop_item_name_fields.rb
+++ b/db/migrate/20150505103111_add_constraints_to_loop_item_name_fields.rb
@@ -1,5 +1,11 @@
 class AddConstraintsToLoopItemNameFields < ActiveRecord::Migration
   def up
+    # if API views already in place, need to drop before changing columns
+    if ActiveRecord::Base.connection.table_exists? 'api_sections_looping_contexts_view'
+      drop_view_and_dependent_views
+      re_create_view = true
+    end
+
     # make loop_item_name_id NOT NULL & add foreign key constraint
     add_index :loop_item_name_fields, :loop_item_name_id
     execute <<-SQL
@@ -40,9 +46,18 @@ class AddConstraintsToLoopItemNameFields < ActiveRecord::Migration
     change_column :loop_item_name_fields, :created_at, :datetime, null: false
     execute "UPDATE loop_item_name_fields SET updated_at = NOW() WHERE updated_at IS NULL"
     change_column :loop_item_name_fields, :updated_at, :datetime, null: false
+
+    # re-create the view if necessary
+    create_view_and_dependent_views if re_create_view
   end
 
   def down
+    # if API views already in place, need to drop before changing columns
+    if ActiveRecord::Base.connection.table_exists? 'api_sections_looping_contexts_view'
+      drop_view_and_dependent_views
+      re_create_view = true
+    end
+
     remove_index :loop_item_name_fields, :loop_item_name_id
     change_column :loop_item_name_fields,
       :loop_item_name_id, :integer, null: true
@@ -61,6 +76,18 @@ class AddConstraintsToLoopItemNameFields < ActiveRecord::Migration
       :created_at, :datetime, null: true
     change_column :loop_item_name_fields,
       :updated_at, :datetime, null: true
+
+    # re-create the view if necessary
+    create_view_and_dependent_views if re_create_view
   end
 
+  def drop_view_and_dependent_views
+    execute 'DROP VIEW api_questions_looping_contexts_view'
+    execute 'DROP VIEW api_sections_looping_contexts_view'
+  end
+
+  def create_view_and_dependent_views
+    execute view_sql('20151111125036', 'api_sections_looping_contexts_view')
+    execute view_sql('20151111125036', 'api_questions_looping_contexts_view')
+  end
 end

--- a/db/migrate/20150505103111_add_constraints_to_loop_item_name_fields.rb
+++ b/db/migrate/20150505103111_add_constraints_to_loop_item_name_fields.rb
@@ -4,9 +4,11 @@ class AddConstraintsToLoopItemNameFields < ActiveRecord::Migration
     add_index :loop_item_name_fields, :loop_item_name_id
     execute <<-SQL
       DELETE FROM loop_item_name_fields
-      WHERE loop_item_name_id IS NULL
-      OR loop_item_name_id NOT IN (
-        SELECT id FROM loop_item_names
+      WHERE id IN (
+        SELECT linf.id
+        FROM loop_item_name_fields AS linf
+        LEFT OUTER JOIN loop_item_names AS lin ON linf.loop_item_name_id = lin.id
+        WHERE lin.id IS NULL OR linf.loop_item_name_id IS NULL
       )
     SQL
 

--- a/db/migrate/20150505115613_add_constraints_to_loop_item_names.rb
+++ b/db/migrate/20150505115613_add_constraints_to_loop_item_names.rb
@@ -4,9 +4,11 @@ class AddConstraintsToLoopItemNames < ActiveRecord::Migration
     add_index :loop_item_names, :loop_source_id
     execute <<-SQL
       DELETE FROM loop_item_names
-      WHERE loop_source_id IS NULL
-      OR loop_source_id NOT IN (
-        SELECT id FROM loop_sources
+      WHERE id IN (
+        SELECT lin.id
+        FROM loop_item_names AS lin
+        LEFT OUTER JOIN loop_sources AS ls ON lin.loop_source_id = ls.id
+        WHERE ls.id IS NULL OR lin.loop_source_id IS NULL
       )
     SQL
 
@@ -22,9 +24,11 @@ class AddConstraintsToLoopItemNames < ActiveRecord::Migration
     add_index :loop_item_names, :loop_item_type_id
     execute <<-SQL
       DELETE FROM loop_item_names
-      WHERE loop_item_type_id IS NULL
-      OR loop_item_type_id NOT IN (
-        SELECT id FROM loop_item_types
+      WHERE id IN (
+        SELECT lin.id
+        FROM loop_item_names AS lin
+        LEFT OUTER JOIN loop_item_types AS lit ON lin.loop_item_type_id = lit.id
+        WHERE lit.id IS NULL OR lin.loop_item_type_id IS NULL
       )
     SQL
 

--- a/db/migrate/20150505121129_add_constraints_to_loop_items.rb
+++ b/db/migrate/20150505121129_add_constraints_to_loop_items.rb
@@ -1,5 +1,6 @@
 class AddConstraintsToLoopItems < ActiveRecord::Migration
   def up
+    # TO AMEND?
     # add foreign key constraint
     # index on parent_id already in place
     execute <<-SQL
@@ -27,9 +28,11 @@ class AddConstraintsToLoopItems < ActiveRecord::Migration
     add_index :loop_items, :loop_item_type_id
     execute <<-SQL
       DELETE FROM loop_items
-      WHERE loop_item_type_id IS NULL
-      OR loop_item_type_id NOT IN (
-        SELECT id FROM loop_item_types
+      WHERE id IN (
+        SELECT li.id
+        FROM loop_items AS li
+        LEFT OUTER JOIN loop_item_types AS lit ON li.loop_item_type_id = lit.id
+        WHERE lit.id IS NULL OR li.loop_item_type_id IS NULL
       )
     SQL
 
@@ -45,9 +48,11 @@ class AddConstraintsToLoopItems < ActiveRecord::Migration
     add_index :loop_items, :loop_item_name_id
     execute <<-SQL
       DELETE FROM loop_items
-      WHERE loop_item_name_id IS NOT NULL
-      AND loop_item_name_id NOT IN (
-        SELECT id FROM loop_item_names
+      WHERE id IN (
+        SELECT li.id
+        FROM loop_items AS li
+        LEFT OUTER JOIN loop_item_names AS lin ON li.loop_item_name_id = lin.id
+        WHERE lin.id IS NULL AND li.loop_item_name_id IS NOT NULL
       )
     SQL
 

--- a/db/migrate/20150505125013_add_constraints_to_source_files.rb
+++ b/db/migrate/20150505125013_add_constraints_to_source_files.rb
@@ -4,9 +4,11 @@ class AddConstraintsToSourceFiles < ActiveRecord::Migration
     add_index :source_files, :loop_source_id
     execute <<-SQL
       DELETE FROM source_files
-      WHERE loop_source_id IS NULL
-      OR loop_source_id NOT IN (
-        SELECT id FROM loop_sources
+      WHERE id IN (
+        SELECT sf.id
+        FROM source_files AS sf
+        LEFT OUTER JOIN loop_sources AS ls ON sf.loop_source_id = ls.id
+        WHERE ls.id IS NULL OR sf.loop_source_id IS NULL
       )
     SQL
 

--- a/db/migrate/20150505131137_add_constraints_to_extras.rb
+++ b/db/migrate/20150505131137_add_constraints_to_extras.rb
@@ -4,9 +4,11 @@ class AddConstraintsToExtras < ActiveRecord::Migration
     add_index :extras, :loop_item_type_id
     execute <<-SQL
       DELETE FROM extras
-      WHERE loop_item_type_id IS NULL
-      OR loop_item_type_id NOT IN (
-        SELECT id FROM loop_item_types
+      WHERE id IN (
+        SELECT e.id
+        FROM extras AS e
+        LEFT OUTER JOIN loop_item_types AS lit ON e.loop_item_type_id = lit.id
+        WHERE lit.id IS NULL OR e.loop_item_type_id IS NULL
       )
     SQL
 

--- a/db/migrate/20150506121547_add_constraints_to_item_extra_fields.rb
+++ b/db/migrate/20150506121547_add_constraints_to_item_extra_fields.rb
@@ -4,9 +4,11 @@ class AddConstraintsToItemExtraFields < ActiveRecord::Migration
     add_index :item_extra_fields, :item_extra_id
     execute <<-SQL
       DELETE FROM item_extra_fields
-      WHERE item_extra_id IS NULL
-      OR item_extra_id NOT IN (
-        SELECT id FROM item_extras
+      WHERE id IN (
+        SELECT ief.id
+        FROM item_extra_fields AS ief
+        LEFT OUTER JOIN item_extras AS ie ON ief.item_extra_id = ie.id
+        WHERE ie.id IS NULL OR ief.item_extra_id IS NULL
       )
     SQL
 

--- a/db/migrate/20150506131025_add_constraints_to_item_extras.rb
+++ b/db/migrate/20150506131025_add_constraints_to_item_extras.rb
@@ -4,9 +4,11 @@ class AddConstraintsToItemExtras < ActiveRecord::Migration
     add_index :item_extras, :loop_item_name_id
     execute <<-SQL
       DELETE FROM item_extras
-      WHERE loop_item_name_id IS NULL
-      OR loop_item_name_id NOT IN (
-        SELECT id FROM loop_item_names
+      WHERE id IN (
+        SELECT ie.id
+        FROM item_extras AS ie
+        LEFT OUTER JOIN loop_item_names AS lin ON ie.loop_item_name_id = lin.id
+        WHERE lin.id IS NULL OR ie.loop_item_name_id IS NULL
       )
     SQL
 
@@ -22,9 +24,11 @@ class AddConstraintsToItemExtras < ActiveRecord::Migration
     add_index :item_extras, :extra_id
     execute <<-SQL
       DELETE FROM item_extras
-      WHERE extra_id IS NULL
-      OR extra_id NOT IN (
-        SELECT id FROM extras
+      WHERE id IN (
+        SELECT ie.id
+        FROM item_extras AS ie
+        LEFT OUTER JOIN extras AS e ON ie.extra_id = e.id
+        WHERE e.id IS NULL OR ie.extra_id IS NULL
       )
     SQL
 

--- a/db/migrate/20150506133407_add_constraints_to_delegated_loop_item_names.rb
+++ b/db/migrate/20150506133407_add_constraints_to_delegated_loop_item_names.rb
@@ -5,9 +5,11 @@ class AddConstraintsToDelegatedLoopItemNames < ActiveRecord::Migration
     add_index :delegated_loop_item_names, :loop_item_name_id
     execute <<-SQL
       DELETE FROM delegated_loop_item_names
-      WHERE loop_item_name_id IS NULL
-      OR loop_item_name_id NOT IN (
-        SELECT id FROM loop_item_names
+      WHERE id IN (
+        SELECT dlin.id
+        FROM delegated_loop_item_names AS dlin
+        LEFT OUTER JOIN loop_item_names AS lin ON dlin.loop_item_name_id = lin.id
+        WHERE lin.id IS NULL OR dlin.loop_item_name_id IS NULL
       )
     SQL
 
@@ -23,9 +25,11 @@ class AddConstraintsToDelegatedLoopItemNames < ActiveRecord::Migration
     add_index :delegated_loop_item_names, :delegation_section_id
     execute <<-SQL
       DELETE FROM delegated_loop_item_names
-      WHERE delegation_section_id IS NOT NULL
-      AND delegation_section_id NOT IN (
-        SELECT id FROM delegation_sections
+      WHERE id IN (
+        SELECT dlin.id
+        FROM delegated_loop_item_names AS dlin
+        LEFT OUTER JOIN delegation_sections AS ds ON dlin.delegation_section_id = ds.id
+        WHERE ds.id IS NULL AND dlin.delegation_section_id IS NOT NULL
       )
     SQL
 

--- a/db/migrate/20150507130909_add_constraints_to_section_fields.rb
+++ b/db/migrate/20150507130909_add_constraints_to_section_fields.rb
@@ -1,5 +1,11 @@
 class AddConstraintsToSectionFields < ActiveRecord::Migration
   def up
+    # if API views already in place, need to drop before changing columns
+    if ActiveRecord::Base.connection.table_exists? 'api_sections_view'
+      drop_view_and_dependent_views
+      re_create_view = true
+    end
+
     # make section_id NOT NULL & add foreign key constraint
     add_index :section_fields, :section_id
     execute <<-SQL
@@ -35,9 +41,18 @@ class AddConstraintsToSectionFields < ActiveRecord::Migration
     change_column :section_fields, :created_at, :datetime, null: false
     execute "UPDATE section_fields SET updated_at = NOW() WHERE updated_at IS NULL"
     change_column :section_fields, :updated_at, :datetime, null: false
+
+    # re-create the view if necessary
+    create_view_and_dependent_views if re_create_view
   end
 
   def down
+    # if API views already in place, need to drop before changing columns
+    if ActiveRecord::Base.connection.table_exists? 'api_sections_view'
+      drop_view_and_dependent_views
+      re_create_view = true
+    end
+
     remove_index :section_fields, :section_id
     change_column :section_fields,
       :section_id, :integer, null: true
@@ -53,6 +68,25 @@ class AddConstraintsToSectionFields < ActiveRecord::Migration
       :created_at, :datetime, null: true
     change_column :section_fields,
       :updated_at, :datetime, null: true
+
+    # re-create the view if necessary
+    create_view_and_dependent_views if re_create_view
+  end
+
+  def drop_view_and_dependent_views
+    execute 'DROP VIEW api_questions_looping_contexts_view'
+    execute 'DROP VIEW api_sections_looping_contexts_view'
+    execute 'DROP VIEW api_questions_tree_view'
+    execute 'DROP VIEW api_sections_tree_view'
+    execute 'DROP VIEW api_sections_view'
+  end
+
+  def create_view_and_dependent_views
+    execute view_sql('20151030151237', 'api_sections_view')
+    execute view_sql('20151109160327', 'api_sections_tree_view')
+    execute view_sql('20160202174508', 'api_questions_tree_view')
+    execute view_sql('20151111125036', 'api_sections_looping_contexts_view')
+    execute view_sql('20151111125036', 'api_questions_looping_contexts_view')
   end
 
 end

--- a/db/migrate/20150507130909_add_constraints_to_section_fields.rb
+++ b/db/migrate/20150507130909_add_constraints_to_section_fields.rb
@@ -4,9 +4,11 @@ class AddConstraintsToSectionFields < ActiveRecord::Migration
     add_index :section_fields, :section_id
     execute <<-SQL
       DELETE FROM section_fields
-      WHERE section_id IS NULL
-      OR section_id NOT IN (
-        SELECT id FROM sections
+      WHERE id IN (
+        SELECT sf.id
+        FROM section_fields AS sf
+        LEFT OUTER JOIN sections AS s ON sf.section_id = s.id
+        WHERE s.id IS NULL OR sf.section_id IS NULL
       )
     SQL
 

--- a/db/migrate/20150507203709_add_constraints_to_sections.rb
+++ b/db/migrate/20150507203709_add_constraints_to_sections.rb
@@ -1,5 +1,11 @@
 class AddConstraintsToSections < ActiveRecord::Migration
   def up
+    # if API views already in place, need to drop before changing columns
+    if ActiveRecord::Base.connection.table_exists? 'api_sections_view'
+      drop_view_and_dependent_views
+      re_create_view = true
+    end
+
     # add foreign key constraint
     add_index :sections, :loop_source_id
     execute <<-SQL
@@ -100,9 +106,18 @@ class AddConstraintsToSections < ActiveRecord::Migration
     change_column :sections, :created_at, :datetime, null: false
     execute "UPDATE sections SET updated_at = NOW() WHERE updated_at IS NULL"
     change_column :sections, :updated_at, :datetime, null: false
+
+    # re-create the view if necessary
+    create_view_and_dependent_views if re_create_view
   end
 
   def down
+    # if API views already in place, need to drop before changing columns
+    if ActiveRecord::Base.connection.table_exists? 'api_sections_view'
+      drop_view_and_dependent_views
+      re_create_view = true
+    end
+
     remove_index :sections, :loop_source_id
     remove_foreign_key :sections, column: :loop_source_id
 
@@ -119,5 +134,24 @@ class AddConstraintsToSections < ActiveRecord::Migration
       :created_at, :datetime, null: true
     change_column :sections,
       :updated_at, :datetime, null: true
+
+    # re-create the view if necessary
+    create_view_and_dependent_views if re_create_view
+  end
+
+  def drop_view_and_dependent_views
+    execute 'DROP VIEW api_questions_looping_contexts_view'
+    execute 'DROP VIEW api_sections_looping_contexts_view'
+    execute 'DROP VIEW api_questions_tree_view'
+    execute 'DROP VIEW api_sections_tree_view'
+    execute 'DROP VIEW api_sections_view'
+  end
+
+  def create_view_and_dependent_views
+    execute view_sql('20151030151237', 'api_sections_view')
+    execute view_sql('20151109160327', 'api_sections_tree_view')
+    execute view_sql('20160202174508', 'api_questions_tree_view')
+    execute view_sql('20151111125036', 'api_sections_looping_contexts_view')
+    execute view_sql('20151111125036', 'api_questions_looping_contexts_view')
   end
 end

--- a/db/migrate/20150507213124_add_constraints_to_question_fields.rb
+++ b/db/migrate/20150507213124_add_constraints_to_question_fields.rb
@@ -1,5 +1,11 @@
 class AddConstraintsToQuestionFields < ActiveRecord::Migration
   def up
+    # if API views already in place, need to drop before changing columns
+    if ActiveRecord::Base.connection.table_exists? 'api_questions_view'
+      drop_view_and_dependent_views
+      re_create_view = true
+    end
+
     # make question_id NOT NULL & add foreign key constraint
     add_index :question_fields, :question_id
     execute <<-SQL
@@ -35,9 +41,18 @@ class AddConstraintsToQuestionFields < ActiveRecord::Migration
     change_column :question_fields, :created_at, :datetime, null: false
     execute "UPDATE question_fields SET updated_at = NOW() WHERE updated_at IS NULL"
     change_column :question_fields, :updated_at, :datetime, null: false
+
+    # re-create the view if necessary
+    create_view_and_dependent_views if re_create_view
   end
 
   def down
+    # if API views already in place, need to drop before changing columns
+    if ActiveRecord::Base.connection.table_exists? 'api_questions_view'
+      drop_view_and_dependent_views
+      re_create_view = true
+    end
+
     remove_index :question_fields, :question_id
     change_column :question_fields,
       :question_id, :integer, null: true
@@ -53,5 +68,18 @@ class AddConstraintsToQuestionFields < ActiveRecord::Migration
       :created_at, :datetime, null: true
     change_column :question_fields,
       :updated_at, :datetime, null: true
+
+    # re-create the view if necessary
+    create_view_and_dependent_views if re_create_view
+  end
+
+  def drop_view_and_dependent_views
+    execute 'DROP VIEW api_questions_tree_view'
+    execute 'DROP VIEW api_questions_view'
+  end
+
+  def create_view_and_dependent_views
+    execute view_sql('20151030151237', 'api_questions_view')
+    execute view_sql('20160202174508', 'api_questions_tree_view')
   end
 end

--- a/db/migrate/20150507213124_add_constraints_to_question_fields.rb
+++ b/db/migrate/20150507213124_add_constraints_to_question_fields.rb
@@ -4,9 +4,11 @@ class AddConstraintsToQuestionFields < ActiveRecord::Migration
     add_index :question_fields, :question_id
     execute <<-SQL
       DELETE FROM question_fields
-      WHERE question_id IS NULL
-      OR question_id NOT IN (
-        SELECT id FROM questions
+      WHERE id IN (
+        SELECT qf.id
+        FROM question_fields AS qf
+        LEFT OUTER JOIN questions AS q ON qf.question_id = q.id
+        WHERE q.id IS NULL OR qf.question_id IS NULL
       )
     SQL
 

--- a/db/migrate/20150508103812_add_constraints_to_questionnaire_fields.rb
+++ b/db/migrate/20150508103812_add_constraints_to_questionnaire_fields.rb
@@ -4,9 +4,11 @@ class AddConstraintsToQuestionnaireFields < ActiveRecord::Migration
     add_index :questionnaire_fields, :questionnaire_id
     execute <<-SQL
       DELETE FROM questionnaire_fields
-      WHERE questionnaire_id IS NULL
-      OR questionnaire_id NOT IN (
-        SELECT id FROM questionnaires
+      WHERE id IN (
+        SELECT qf.id
+        FROM questionnaire_fields AS qf
+        LEFT OUTER JOIN questionnaires AS q ON qf.questionnaire_id = q.id
+        WHERE q.id IS NULL OR qf.questionnaire_id IS NULL
       )
     SQL
 

--- a/db/migrate/20150508103812_add_constraints_to_questionnaire_fields.rb
+++ b/db/migrate/20150508103812_add_constraints_to_questionnaire_fields.rb
@@ -1,5 +1,11 @@
 class AddConstraintsToQuestionnaireFields < ActiveRecord::Migration
   def up
+    # if API views already in place, need to drop before changing columns
+    if ActiveRecord::Base.connection.table_exists? 'api_questionnaires_view'
+      drop_view_and_dependent_views
+      re_create_view = true
+    end
+
     # make questionnaire_id NOT NULL & add foreign key constraint
     add_index :questionnaire_fields, :questionnaire_id
     execute <<-SQL
@@ -35,9 +41,18 @@ class AddConstraintsToQuestionnaireFields < ActiveRecord::Migration
     change_column :questionnaire_fields, :created_at, :datetime, null: false
     execute "UPDATE questionnaire_fields SET updated_at = NOW() WHERE updated_at IS NULL"
     change_column :questionnaire_fields, :updated_at, :datetime, null: false
+
+    # re-create the view if necessary
+    create_view_and_dependent_views if re_create_view
   end
 
   def down
+    # if API views already in place, need to drop before changing columns
+    if ActiveRecord::Base.connection.table_exists? 'api_questionnaires_view'
+      drop_view_and_dependent_views
+      re_create_view = true
+    end
+
     remove_index :questionnaire_fields, :questionnaire_id
     change_column :questionnaire_fields,
       :questionnaire_id, :integer, null: true
@@ -53,6 +68,16 @@ class AddConstraintsToQuestionnaireFields < ActiveRecord::Migration
       :created_at, :datetime, null: true
     change_column :questionnaire_fields,
       :updated_at, :datetime, null: true
+
+    # re-create the view if necessary
+    create_view_and_dependent_views if re_create_view
   end
 
+  def drop_view_and_dependent_views
+    execute 'DROP VIEW api_questionnaires_view'
+  end
+
+  def create_view_and_dependent_views
+    execute view_sql('20151030151237', 'api_questionnaires_view')
+  end
 end

--- a/db/migrate/20150508122915_add_constraints_to_questionnaire_parts.rb
+++ b/db/migrate/20150508122915_add_constraints_to_questionnaire_parts.rb
@@ -4,9 +4,11 @@ class AddConstraintsToQuestionnaireParts < ActiveRecord::Migration
     # index on parent_id already in place
     execute <<-SQL
       DELETE FROM questionnaire_parts
-      WHERE parent_id IS NOT NULL
-      AND parent_id NOT IN (
-        SELECT id FROM questionnaire_parts
+      WHERE id IN (
+        SELECT qp.id
+        FROM questionnaire_parts AS qp
+        LEFT OUTER JOIN questionnaire_parts AS qp2 ON qp.parent_id = qp2.id
+        WHERE qp2.id IS NULL AND qp.parent_id IS NOT NULL
       )
     SQL
 
@@ -20,9 +22,11 @@ class AddConstraintsToQuestionnaireParts < ActiveRecord::Migration
     add_index :questionnaire_parts, :questionnaire_id
     execute <<-SQL
       DELETE FROM questionnaire_parts
-      WHERE questionnaire_id IS NOT NULL
-      AND questionnaire_id NOT IN (
-        SELECT id FROM questionnaires
+      WHERE id IN (
+        SELECt qp.id
+        FROM questionnaire_parts AS qp
+        LEFT OUTER JOIN questionnaires AS q ON qp.questionnaire_id = q.id
+        WHERE q.id IS NULL AND qp.questionnaire_id IS NOT NULL
       )
     SQL
 

--- a/db/migrate/20150511140436_add_constraints_to_authorized_submitters.rb
+++ b/db/migrate/20150511140436_add_constraints_to_authorized_submitters.rb
@@ -1,5 +1,11 @@
 class AddConstraintsToAuthorizedSubmitters < ActiveRecord::Migration
   def up
+    # if API views already in place, need to drop before changing columns
+    if ActiveRecord::Base.connection.table_exists? 'api_respondents_view'
+      drop_view_and_dependent_views
+      re_create_view = true
+    end
+
     # make user_id NOT NULL & add foreign key constraint
     add_index :authorized_submitters, :user_id
     execute <<-SQL
@@ -53,9 +59,18 @@ class AddConstraintsToAuthorizedSubmitters < ActiveRecord::Migration
     change_column :authorized_submitters, :created_at, :datetime, null: false
     execute "UPDATE authorized_submitters SET updated_at = NOW() WHERE updated_at IS NULL"
     change_column :authorized_submitters, :updated_at, :datetime, null: false
+
+    # re-create the view if necessary
+    create_view_and_dependent_views if re_create_view
   end
 
   def down
+    # if API views already in place, need to drop before changing columns
+    if ActiveRecord::Base.connection.table_exists? 'api_respondents_view'
+      drop_view_and_dependent_views
+      re_create_view = true
+    end
+
     remove_index :authorized_submitters, :user_id
     change_column :authorized_submitters,
       :user_id, :integer, null: true
@@ -70,5 +85,16 @@ class AddConstraintsToAuthorizedSubmitters < ActiveRecord::Migration
       :created_at, :datetime, null: true
     change_column :authorized_submitters,
       :updated_at, :datetime, null: true
+
+    # re-create the view if necessary
+    create_view_and_dependent_views if re_create_view
+  end
+
+  def drop_view_and_dependent_views
+    execute 'DROP VIEW api_respondents_view'
+  end
+
+  def create_view_and_dependent_views
+    execute view_sql('20151030151237', 'api_respondents_view')
   end
 end


### PR DESCRIPTION
- speeds up long-running migrations that get stuck when applied to the CMS instance
- fixes migrations that are being applied to the CITES instance which has blocking API views in place