### PR TITLE
Add dirty class to text answer to trigger save afterwards

### DIFF
--- a/app/assets/javascripts/respondent/accept_answer.js
+++ b/app/assets/javascripts/respondent/accept_answer.js
@@ -3,6 +3,8 @@ $(document).ready(function() {
     e.preventDefault();
     answer = $(this).closest('.delegate-text-answer').find('textarea').val();
     text_answer = $(this).closest('.answer_fields_wrapper').find('.text-answer')
-    $(text_answer).find('.text-answer-field').val(answer);
+    text_answer_field = $(text_answer).find('.text-answer-field')
+    $(text_answer_field).val(answer);
+    $(text_answer_field).addClass('dirty')
   });
 });


### PR DESCRIPTION
This fixes the `accept answer` functionality.
It wasn't saving the copied answer when clicking save. The answer has to be marked as `dirty`