### PR TITLE
Check for parents sections when looking for delegation authorisation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -346,11 +346,11 @@ class User < ActiveRecord::Base
 
   def can_edit_delegate_text_answer?(section, user_delegate)
     questionnaire_id = section.questionnaire.id
+    delegation = user_delegate.delegations.
+      find_by_questionnaire_id_and_user_delegate_id(questionnaire_id, user_delegate.id)
     if self.role?(:delegate) && (
-      section.is_delegated?(user_delegate.id) ||
-        user_delegate.delegations.
-          find_by_questionnaire_id_and_user_delegate_id(questionnaire_id, user_delegate.id).
-            try(:can_view_and_edit_all_questionnaire?)
+      section.is_or_has_parents_delegated_to?(delegation) ||
+        delegation.try(:can_view_and_edit_all_questionnaire?)
     )
       return true
     end


### PR DESCRIPTION
As reported by Manuel:

```
When Delegating a section with subsections (e.g. Goal 2), only part of the subsection’s answers are accessible by the delegate. All the textboxes are greyed out and no additional box is shown. See below the Delegate’s view of “Goal 2” that has been delegated to him
```

![image009](https://cloud.githubusercontent.com/assets/1244329/19273578/e62189f0-8fc4-11e6-98f2-30ac50c162a2.png)

The issue could be found in the method that is checking if a delegate is authorised to answer that subsection, which method, for every subsection, was checking the permissions just for that subsection itself rather than considering the parents as well.