### PR TITLE
Amend mark question as answered

### DIFF
--- a/app/assets/javascripts/respondent/accept_answer.js
+++ b/app/assets/javascripts/respondent/accept_answer.js
@@ -2,9 +2,14 @@ $(document).ready(function() {
   $(document).on('click', '.accept-btn', function(e) {
     e.preventDefault();
     answer = $(this).closest('.delegate-text-answer').find('textarea').val();
-    text_answer = $(this).closest('.answer_fields_wrapper').find('.text-answer')
+    answer_wrapper = $(this).closest('.answer_fields_wrapper')
+    text_answer = $(answer_wrapper).find('.text-answer')
     text_answer_field = $(text_answer).find('.text-answer-field')
-    $(text_answer_field).val(answer);
-    $(text_answer_field).addClass('dirty')
+    question_answered = $(answer_wrapper).find('.answer-details').
+      find('.question-answered-box').prop('checked')
+    if(!question_answered) {
+      $(text_answer_field).val(answer);
+      $(text_answer_field).addClass('dirty');
+    }
   });
 });

--- a/app/assets/javascripts/respondent/question_answered.js
+++ b/app/assets/javascripts/respondent/question_answered.js
@@ -1,0 +1,15 @@
+$(document).ready(function() {
+  $(document).on('change', '.question-answered-box', function(){
+    text_answer_field = $(this).closest('.text-answer').find('.text-answer-field')
+    if($(this).prop('checked')) {
+      $(text_answer_field).attr("readonly", true)
+      $(text_answer_field).addClass("disabled")
+    }
+    else {
+      $(text_answer_field).attr("disabled", false)
+      $(text_answer_field).attr("readonly", false)
+      $(text_answer_field).removeClass("disabled")
+      $('.sticky_save_all').click();
+    }
+  });
+});

--- a/app/assets/stylesheets/respondent/style.scss
+++ b/app/assets/stylesheets/respondent/style.scss
@@ -52,7 +52,10 @@ input[type='checkbox'] { margin: 0 5px 0 0; }
 
   textarea {
     padding: 10px;
-    &.disabled { background-color: $grey-5; }
+  }
+
+  .text-answer-field.disabled {
+    background-color: $grey-5;
   }
 
   .answer-details {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -346,13 +346,11 @@ class User < ActiveRecord::Base
 
   def can_edit_delegate_text_answer?(section, user_delegate)
     questionnaire_id = section.questionnaire.id
-    delegation = user_delegate.delegations.
-      find_by_questionnaire_id_and_user_delegate_id(questionnaire_id, user_delegate.id)
-    if self.role?(:delegate) && (
-      section.is_or_has_parents_delegated_to?(delegation) ||
-        delegation.try(:can_view_and_edit_all_questionnaire?)
-    )
-      return true
+    if self.role?(:delegate)
+      delegation = user_delegate.delegations.
+        find_by_questionnaire_id_and_user_delegate_id(questionnaire_id, user_delegate.id)
+      return section.is_or_has_parents_delegated_to?(delegation) ||
+           delegation.try(:can_view_and_edit_all_questionnaire?)
     end
     return false
   end

--- a/app/views/questions/_answer_details.html.erb
+++ b/app/views/questions/_answer_details.html.erb
@@ -21,7 +21,8 @@
   <% if answer && answer.user_id == current_user.id %>
     <div class="row padded">
       <%= hidden_field_tag "question_answered[#{answer.id}]", "" %>
-      <%= (check_box_tag "question_answered[#{answer.id}]", true, answer.question_answered) + 'Mark question as answered' %>
+      <%= check_box_tag "question_answered[#{answer.id}]", true, answer.question_answered, class: "question-answered-box" %>
+      <%= label_tag "question_answered[#{answer.id}]", "Mark question as answered" %>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
As reported by Manuel:

```
Also, the “Mark question as answered” on the delegate interface might need some improvements:
a.      The field gets greyed out only after reloading the page
b.      One can still click “Accept Answer” and the answer gets copied over even though the mark as
answered is clicked
```

So "Accept Answer" won't work now if the question has been marked as answered, and the "Mark as answered" functionality now works without reloading the page, at the price of saving all each time that checkbox is unticked.

I've also fixed a bug affecting delegations authorisation, returning a `method not defined for nil` caused by checking delegations for respondents as well.

Short text inputs didn't have a grey background when  disabled, so I applied that for both textarea and text input.