### PR TITLE
Add question

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -9,7 +9,7 @@ class Question < ActiveRecord::Base
   attr_accessible :section_id, :answer_type_id, :answer_type_type,
     :question_fields_attributes, :is_mandatory, :answer_type,
     :loop_item_type_ids, :question_extras_ids, :other_text,
-    :allow_attachments
+    :allow_attachments, :uidentifier
   #attr_protected :id, :created_at, :updated_at, :last_edited, :answer_type
 
   before_destroy :destroy_answer_type

--- a/app/views/questions/_form.html.erb
+++ b/app/views/questions/_form.html.erb
@@ -6,6 +6,10 @@
   <a href="#" class="show_all_lang_fields btn">Expand all</a>
   <a href="#" class="hide_all_lang_fields btn">Collapse all</a>
 </li>
+<div class="row padded">
+  <div class="col col-4"><%= f.label(:uidentifier){ 'ID' } %></div>
+  <div class="col col-8 border-left"><%= f.text_field :uidentifier %></div>
+</div>
 <li>
   <%= f.fields_for :question_fields, f.object.question_fields.sort_by{ |a| a.is_default_language? ? 0 : 1 } do |builder| %>
       <div class="<%= builder.object.is_default_language? ? "" : "hide"%> lang_fields" id="fields_for_quest_<%= builder.object.language %>">

--- a/app/views/questions/_show.html.erb
+++ b/app/views/questions/_show.html.erb
@@ -24,6 +24,8 @@
           </div>
           <div class="language-content info-content <%= field.is_default_language? ? "" : "hidden-content" %>">
             <% title = strip_tags( Sanitize.clean(field.title.present? ? field.title : "#Not Specified#", OrtSanitize::Config::ORT)) -%>
+            <%= content_field("ID", @question.uidentifier) %>
+
             <%= content_field("Full title", title) %>
 
             <%= content_field("Short title", field.short_title) %>

--- a/db/migrate/20161115121351_copy_question_short_title_to_uidentifier.rb
+++ b/db/migrate/20161115121351_copy_question_short_title_to_uidentifier.rb
@@ -1,0 +1,26 @@
+class CopyQuestionShortTitleToUidentifier < ActiveRecord::Migration
+  def up
+    # This will copy content of short_title from question_fields
+    # into questions.uidentifier, with the purpose of using it as
+    # an internal reference for the organisation (RAMSAR).
+    # uidentifier is a field already present in the database,
+    # but without any apparent purpose.
+    # short_title is a multilingual field, we take MAX and hope
+    # that's the best match.
+    execute <<-SQL
+    WITH short_titles AS (
+      SELECT question_id, MAX(short_title) AS uidentifier
+      from question_fields
+      group by question_id
+    )
+    UPDATE questions
+    SET uidentifier = short_titles.uidentifier
+    FROM short_titles
+    WHERE question_id = questions.id
+    SQL
+  end
+
+  def down
+    execute 'UPDATE questions SET uidentifier = NULL'
+  end
+end

--- a/db/questionnaire_cloning_scripts/004_copy_questions.sql
+++ b/db/questionnaire_cloning_scripts/004_copy_questions.sql
@@ -61,6 +61,7 @@ BEGIN
     AND tmp.original_id = questions_to_copy.answer_type_id
   )
   INSERT INTO tmp_questions (
+    uidentifier,
     section_id,
     answer_type_id,
     answer_type_type,
@@ -71,6 +72,7 @@ BEGIN
     original_id
   )
   SELECT
+    uidentifier,
     tmp_sections.id,
     new_answer_type_id,
     t.answer_type_type,


### PR DESCRIPTION
The required change is to add a field to store a question id set by the questionnaire crateor and used as an internal reference. Instead of adding a new field to hold a question id, it was possible to reuse the so far empty questions.uidentifier field, which is a text field up to 256 characters and should do for the purpose. Populated the field with contents of question_fields.short_title.