### PR TITLE
Logged in as admin required for filtering fields and loop sources

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -82,8 +82,4 @@ class ApplicationController < ActionController::Base
   def set_current_user_delegate
     @current_user_delegate = UserDelegate.find(params[:user_delegate]) if params[:user_delegate].present?
   end
-
-  def admin_required
-    raise CanCan::AccessDenied.new(t('flash_messages.not_authorized')) if !current_user || !current_user.role?(:admin)
-  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -82,4 +82,8 @@ class ApplicationController < ActionController::Base
   def set_current_user_delegate
     @current_user_delegate = UserDelegate.find(params[:user_delegate]) if params[:user_delegate].present?
   end
+
+  def admin_required
+    raise CanCan::AccessDenied.new(t('flash_messages.not_authorized')) if !current_user || !current_user.role?(:admin)
+  end
 end

--- a/app/controllers/filtering_fields_controller.rb
+++ b/app/controllers/filtering_fields_controller.rb
@@ -1,5 +1,7 @@
 class FilteringFieldsController < ApplicationController
-  before_filter :admin_required
+
+  authorize_resource
+
   # GET /filtering_fields
   # GET /filtering_fields.xml
   def index

--- a/app/controllers/filtering_fields_controller.rb
+++ b/app/controllers/filtering_fields_controller.rb
@@ -1,4 +1,5 @@
 class FilteringFieldsController < ApplicationController
+  before_filter :admin_required
   # GET /filtering_fields
   # GET /filtering_fields.xml
   def index

--- a/app/controllers/loop_sources_controller.rb
+++ b/app/controllers/loop_sources_controller.rb
@@ -1,5 +1,7 @@
 class LoopSourcesController < ApplicationController
 
+  before_filter :admin_required
+
   def index
     #@loop_sources = LoopSource.all
     @questionnaire = Questionnaire.find(params[:questionnaire_id], :include => [{:loop_sources => :loop_item_type}, :questionnaire_fields])
@@ -112,4 +114,5 @@ class LoopSourcesController < ApplicationController
       format.js
     end
   end
+
 end

--- a/app/controllers/loop_sources_controller.rb
+++ b/app/controllers/loop_sources_controller.rb
@@ -1,6 +1,6 @@
 class LoopSourcesController < ApplicationController
 
-  before_filter :admin_required
+  authorize_resource
 
   def index
     #@loop_sources = LoopSource.all


### PR DESCRIPTION
Not logged in users where able to access admin pages like loop_sources and filtering_fields.
Added restriction to controllers to require a logged in user which is also an admin.