### PR TITLE
Added validation to allow special characters in email addresses

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,9 +49,11 @@ GEM
     ast (2.0.0)
     astrolabe (1.3.0)
       parser (>= 2.2.0.pre.3, < 3.0)
-    authlogic (3.3.0)
-      activerecord (>= 3.2)
-      activesupport (>= 3.2)
+    authlogic (3.5.0)
+      activerecord (>= 3.2, < 5.1)
+      activesupport (>= 3.2, < 5.1)
+      request_store (~> 1.0)
+      scrypt (>= 1.2, < 4.0)
     awesome_nested_set (2.1.6)
       activerecord (>= 3.0.0)
     builder (3.0.4)
@@ -147,6 +149,10 @@ GEM
     faker (1.6.6)
       i18n (~> 0.5)
     fastercsv (1.5.5)
+    ffi (1.9.17)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
     font-awesome-rails (4.3.0.0)
       railties (>= 3.2, < 5.0)
     foreigner (1.5.0)
@@ -158,7 +164,7 @@ GEM
     hike (1.2.3)
     hitimes (1.2.2)
     htmlentities (4.3.3)
-    i18n (0.7.0)
+    i18n (0.8.0)
     journey (1.0.4)
     jqgrid-jquery-rails (4.4.5.0)
       jquery-rails
@@ -191,7 +197,7 @@ GEM
       minitest (~> 4.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
-    multi_json (1.11.2)
+    multi_json (1.12.1)
     nenv (0.2.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -254,6 +260,7 @@ GEM
     redis (3.2.1)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
+    request_store (1.3.2)
     rspec-logsplit (0.1.3)
     rubocop (0.31.0)
       astrolabe (~> 1.3)
@@ -271,6 +278,9 @@ GEM
       railties (~> 3.2.0)
       sass (>= 3.1.10)
       tilt (~> 1.3)
+    scrypt (3.0.3)
+      ffi-compiler (>= 1.0.0)
+      rake
     select2-rails (4.0.0)
       thor (~> 0.14)
     sexy_relations (1.0.4)
@@ -319,7 +329,7 @@ GEM
       polyglot
       polyglot (>= 0.3.1)
     ttfunk (1.0.3)
-    tzinfo (0.3.44)
+    tzinfo (0.3.52)
     uglifier (2.7.0)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
@@ -392,4 +402,4 @@ DEPENDENCIES
   uglifier
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,7 @@ class User < ActiveRecord::Base
     c.login_field = 'email'
     c.disable_perishable_token_maintenance true
     c.validates_format_of_email_field_options = {:with => Authlogic::Regex.email_nonascii}
+    c.merge_validates_length_of_password_field_options({:minimum => 5})
   end
 
   ###

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,7 @@ class User < ActiveRecord::Base
   acts_as_authentic do |c|
     c.login_field = 'email'
     c.disable_perishable_token_maintenance true
+    c.validates_format_of_email_field_options({:with => Authlogic::Regex.email_nonascii})
   end
 
   ###

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@ class User < ActiveRecord::Base
   acts_as_authentic do |c|
     c.login_field = 'email'
     c.disable_perishable_token_maintenance true
-    c.validates_format_of_email_field_options({:with => Authlogic::Regex.email_nonascii})
+    c.validates_format_of_email_field_options = {:with => Authlogic::Regex.email_nonascii}
   end
 
   ###


### PR DESCRIPTION
email_name_regex disallows: @[]^ !“#$()*,/:;<=>?`{|}~\ and control characters
domain_head_regex disallows: _%+ and all characters in email_name_regex
domain_tld_regex disallows: 0123456789- and all characters in domain_head_regex