### PR TITLE
Wrong info when adding user

### DIFF
--- a/app/assets/javascripts/components/users/base.js.coffee
+++ b/app/assets/javascripts/components/users/base.js.coffee
@@ -7,15 +7,16 @@ window.UsersComponent = class UsersComponent
 
   @userDetailsTooltip: ->
     tooltipClass = '.information-tooltip'
-    $("#{tooltipClass}-trigger").toggle( (ev) ->
+    $(document).on('click', "#{tooltipClass}-trigger", (ev) ->
       ev.preventDefault()
-      $("#{tooltipClass}-trigger").not(@).siblings(tooltipClass).hide()
-      $(@).html('<i class="fa fa-close"></i> close')
-      $(@).siblings(tooltipClass).show()
-    , (ev) ->
-      ev.preventDefault()
-      $(@).html('<i class="fa fa-align-left"></i> details')
-      $(@).siblings(tooltipClass).hide()
+      if ($(@).find('.fa-align-left').length)
+        $("#{tooltipClass}-trigger").not(@).siblings(tooltipClass).hide()
+        $("#{tooltipClass}-trigger").not(@).html('<i class="fa fa-align-left"></i> details')
+        $(@).html('<i class="fa fa-close"></i> close')
+        $(@).siblings(tooltipClass).show()
+      else
+        $(@).html('<i class="fa fa-align-left"></i> details')
+        $(@).siblings(tooltipClass).hide()
     )
 
 $(document).ready -> UsersComponent.initialize()

--- a/app/assets/javascripts/components/users/base.js.coffee
+++ b/app/assets/javascripts/components/users/base.js.coffee
@@ -9,14 +9,15 @@ window.UsersComponent = class UsersComponent
     tooltipClass = '.information-tooltip'
     $(document).on('click', "#{tooltipClass}-trigger", (ev) ->
       ev.preventDefault()
-      if ($(@).find('.fa-align-left').length)
+      $this = $(@)
+      if ($this.find('.fa-align-left').length)
         $("#{tooltipClass}-trigger").not(@).siblings(tooltipClass).hide()
         $("#{tooltipClass}-trigger").not(@).html('<i class="fa fa-align-left"></i> details')
-        $(@).html('<i class="fa fa-close"></i> close')
-        $(@).siblings(tooltipClass).show()
+        $this.html('<i class="fa fa-close"></i> close')
+        $this.siblings(tooltipClass).show()
       else
-        $(@).html('<i class="fa fa-align-left"></i> details')
-        $(@).siblings(tooltipClass).hide()
+        $this.html('<i class="fa fa-align-left"></i> details')
+        $this.siblings(tooltipClass).hide()
     )
 
 $(document).ready -> UsersComponent.initialize()

--- a/app/views/users/_new.html.erb
+++ b/app/views/users/_new.html.erb
@@ -64,11 +64,11 @@
               <div class="clear">
                 <p>Roles</p>
                 <ul>
-                  <%= hidden_field_tag "user[role_ids][]", "" %>
                   <% for role in Role.all %>
-                      <li><label><%=h role.name.titleize %></label>
-                        <%= check_box_tag( "role_#{role.name}" ) %>
-                      </li>
+                    <li>
+                      <label><%=h role.name.titleize %></label>
+                      <%= check_box_tag("user[role_ids][]", role.id) %>
+                    </li>
                   <% end -%>
                 </ul>
               </div>

--- a/app/views/users/create.js.erb
+++ b/app/views/users/create.js.erb
@@ -19,12 +19,13 @@ $(function() {
             $users_index.prepend("<tr id='row_<%=@user.id.to_s%>'>" +
                                   "<td><%= escape_javascript( check_box_tag "users["+@user.id.to_s+"]", @user.id.to_s, false, {:class => "checkboxes"} ) %></td>" +
                                   "<td><%= escape_javascript(link_to h(@user.full_name), user_path(@user)) %></td>"+
-                                  "<td><%= escape_javascript(mail_to @user.email, h(@user.email))%></td>"+
-                                  "<td><%= escape_javascript(@user.created_at.to_formatted_s(:long_ordinal)) %></td>"+
-                                  "<td><%= escape_javascript(@user.creator ? "#{link_to h(@user.creator.full_name), user_path(@user.creator)}" : "None").html_safe %></td>"+
+                                  "<td><%= @user.created_at.strftime("%d/%m/%Y") %></td>"+
                                   "<td><%= @user.roles.map(&:name).join(', ') if @user.roles.present? %></td>"+
                                   "<td id='groups_<%=@user.id.to_s%>' class='user_groups'></td>"+
-                                  "<td></td>"+
+                                  "<td>"+
+                                    "<a href='#' class='information-tooltip-trigger'><%= escape_javascript(fa_icon 'align-left') %> details</a> | <%= escape_javascript(link_to "view", @user) %>" +
+                                  " | <%= escape_javascript(link_to "delete", delete_user_path(@user)) if !@user.role?(:admin) %>" +
+                                  "</td>" +
                                   "</tr>")
                         .trigger("update") //tell the table that it has been updated
                         .trigger("sorton",[[]]); //remove the sorting

--- a/app/views/users/create.js.erb
+++ b/app/views/users/create.js.erb
@@ -16,6 +16,14 @@ $(function() {
             $myTable.trigger("sorton",[[]]); //remove the sorting
         <% else %>
             var $users_index = $("#users_index");
+            var info_tooltip =
+              "<div class='information-tooltip hide'>" +
+                "<p><strong>Email</strong></p> <%= @user.email %> " +
+                "<p><strong>Country</strong></p> <%= @user.country %> " +
+                "<p><strong>Region</strong></p> <%= @user.region %> " +
+                "<p><strong>Created by</strong></p> <%= escape_javascript(raw @user.creator ? "#{link_to h(@user.creator.full_name), user_path(@user.creator)}" : "None") %> " +
+                "<p><strong>Category</strong></p> <%= @user.category.presence || "Other" %> " +
+              "</div>";
             $users_index.prepend("<tr id='row_<%=@user.id.to_s%>'>" +
                                   "<td><%= escape_javascript( check_box_tag "users["+@user.id.to_s+"]", @user.id.to_s, false, {:class => "checkboxes"} ) %></td>" +
                                   "<td><%= escape_javascript(link_to h(@user.full_name), user_path(@user)) %></td>"+
@@ -23,6 +31,7 @@ $(function() {
                                   "<td><%= @user.roles.map(&:name).join(', ') if @user.roles.present? %></td>"+
                                   "<td id='groups_<%=@user.id.to_s%>' class='user_groups'></td>"+
                                   "<td>"+
+                                    info_tooltip +
                                     "<a href='#' class='information-tooltip-trigger'><%= escape_javascript(fa_icon 'align-left') %> details</a> | <%= escape_javascript(link_to "view", @user) %>" +
                                   " | <%= escape_javascript(link_to "delete", delete_user_path(@user)) if !@user.role?(:admin) %>" +
                                   "</td>" +


### PR DESCRIPTION
This is about fixing the process of creating a new user.
When adding a new user through 'Manage Users' as an admin two things were happening:
  1. The new row of the added user was displaying incorrectly, with wrong columns and data format
  2. Regardless of the selected roles, just the 'respondent' one was added.

This fixes both.