### PR TITLE
Order matrix answer options by descending id to match the creation order

### DIFF
--- a/app/views/matrix_answers/_form.html.erb
+++ b/app/views/matrix_answers/_form.html.erb
@@ -88,17 +88,18 @@
                     <% end -%>
                 ];
             <% j = 0 %>
+                <% matrix_answer_options =  type.matrix_answer_options.order('id DESC') %>
                 var optionsData = [
-                    <% type.matrix_answer_options.sort{|a,b| a.created_at <=> b.created_at }.each_index do |i| %>
+                    <% matrix_answer_options.each_index do |i| %>
                         {
                           id: "<%= j %>",
-                          <% option_fields = type.matrix_answer_options[i].matrix_answer_option_fields.sort_by{|a| a.is_default_language? ? 0 : 1} %>
+                          <% option_fields = matrix_answer_options[i].matrix_answer_option_fields.sort_by{|a| a.is_default_language? ? 0 : 1} %>
                           <% option_fields.each_with_index do |of, n| %>
                             "<%= of.language_english_name %>": "<%= escape_javascript(of.title) %>"<%= "," if n < option_fields.size %>
                           <% end %>
-                          <%#= ", " + type.matrix_answer_options[i].matrix_answer_option_fields.sort_by{ |a| a.is_default_language? ? 0 : 1 }.map{|a| "#{a.language_english_name} : '#{h(a.title)}'"}.join(', ') %>
+                          <%#= ", " + matrix_answer_options[i].matrix_answer_option_fields.sort_by{ |a| a.is_default_language? ? 0 : 1 }.map{|a| "#{a.language_english_name} : '#{h(a.title)}'"}.join(', ') %>
                         }
-                        <% if i < type.matrix_answer_options.size %>
+                        <% if i < matrix_answer_options.size %>
                             ,
                         <% end -%>
                         <% j += 1 %>

--- a/app/views/matrix_answers/_show.html.erb
+++ b/app/views/matrix_answers/_show.html.erb
@@ -17,7 +17,7 @@
 </ul>
 <p>Options</p>
 <ul>
-  <% answer_type.matrix_answer_options.each do |option| %>
+  <% answer_type.matrix_answer_options.order('id DESC').each do |option| %>
       <li>
         <%= h option.title(language) %>
       </li>

--- a/app/views/matrix_answers/_submission.html.erb
+++ b/app/views/matrix_answers/_submission.html.erb
@@ -1,6 +1,6 @@
 <% queries_as_rows = answer_type.matrix_orientation == 0 %>
-<% columns = queries_as_rows ? answer_type.matrix_answer_options : answer_type.matrix_answer_queries  -%>
-<% rows = queries_as_rows ? answer_type.matrix_answer_queries : answer_type.matrix_answer_options  -%>
+<% columns = queries_as_rows ? answer_type.matrix_answer_options.order('id DESC') : answer_type.matrix_answer_queries  -%>
+<% rows = queries_as_rows ? answer_type.matrix_answer_queries : answer_type.matrix_answer_options.order('id DESC')  -%>
 <% drop_down_options = answer_type.matrix_answer_drop_options %>
 <% selection = {} %>
 <% if answer


### PR DESCRIPTION
Matrix options were showing in the reverse order in respect to the creation order.
Apparently the browser sends the object in the reverse order for some reason.
A quick way through this is to order by descending id the options themselves when rendering those into the page.