### PR TITLE
Fix matrix queries order and preview

### DIFF
--- a/app/views/matrix_answers/_form.html.erb
+++ b/app/views/matrix_answers/_form.html.erb
@@ -71,17 +71,18 @@
 
         <% else -%>
             <% j = 0 %>
+                <% matrix_answer_queries =  type.matrix_answer_queries.order('id DESC') %>
                 var queriesData = [
-                    <% type.matrix_answer_queries.sort{ |a, b| a.created_at <=> b.created_at }.each_index do |i| %>
+                    <% matrix_answer_queries.each_index do |i| %>
                         {
                             id: "<%= j %>",
-                            <% query_fields = type.matrix_answer_queries[i].matrix_answer_query_fields.sort_by{|a| a.is_default_language? ? 0 : 1} %>
+                            <% query_fields = matrix_answer_queries[i].matrix_answer_query_fields.sort_by{|a| a.is_default_language? ? 0 : 1} %>
                             <% query_fields.each_with_index do |qf, n| %>
                               "<%= qf.language_english_name %>": "<%= escape_javascript(qf.title) %>"<%= "," if n < query_fields.size %>
                             <% end %>
-                            <%#= ", " + type.matrix_answer_queries[i].matrix_answer_query_fields.sort_by{ |a| a.is_default_language? ? 0 : 1 }.map{|a| "#{a.language_english_name} : '#{h(a.title)}'"}.join(', ') %>
+                            <%#= ", " + matrix_answer_queries[i].matrix_answer_query_fields.sort_by{ |a| a.is_default_language? ? 0 : 1 }.map{|a| "#{a.language_english_name} : '#{h(a.title)}'"}.join(', ') %>
                         }
-                        <% if i < type.matrix_answer_queries.size %>
+                        <% if i < matrix_answer_queries.size %>
                                 ,
                         <% end -%>
                         <% j += 1 %>

--- a/app/views/matrix_answers/_form.html.erb
+++ b/app/views/matrix_answers/_form.html.erb
@@ -109,17 +109,18 @@
                 var dropOptionsData = [];
             <% if type.display_reply == 3 -%>
             <% j = 0 %>
+                <% matrix_answer_drop_options =  type.matrix_answer_drop_options.order('id DESC') %>
                 dropOptionsData = [
-                    <% type.matrix_answer_drop_options.sort{|a,b| a.created_at <=> b.created_at }.each_index do |i| %>
+                    <% matrix_answer_drop_options.each_index do |i| %>
                         {
                             id: "<%= j %>",
-                            <% drop_option_fields = type.matrix_answer_drop_options[i].matrix_answer_drop_option_fields.sort_by{|a| a.is_default_language? ? 0 : 1} %>
+                            <% drop_option_fields = matrix_answer_drop_options[i].matrix_answer_drop_option_fields.sort_by{|a| a.is_default_language? ? 0 : 1} %>
                             <% drop_option_fields.each_with_index do |dof, n| %>
                               "<%= dof.language_english_name %>": "<%= escape_javascript(dof.option_text) %>"<%= "," if n < drop_option_fields.size %>
                             <% end %>
-                            <%#= ", " + type.matrix_answer_drop_options[i].matrix_answer_drop_option_fields.sort_by{ |a| a.is_default_language? ? 0 : 1 }.map{|a| "#{a.language_english_name} : '#{h(a.option_text)}'"}.join(', ') %>
+                            <%#= ", " + matrix_answer_drop_options[i].matrix_answer_drop_option_fields.sort_by{ |a| a.is_default_language? ? 0 : 1 }.map{|a| "#{a.language_english_name} : '#{h(a.option_text)}'"}.join(', ') %>
                         }
-                        <% if i < type.matrix_answer_drop_options.size %>
+                        <% if i < matrix_answer_drop_options.size %>
                             ,
                         <% end -%>
                         <% j += 1 %>

--- a/app/views/matrix_answers/_preview.html.erb
+++ b/app/views/matrix_answers/_preview.html.erb
@@ -30,7 +30,7 @@
               <% elsif answer_type.drop_down_list? -%>
                 <%
                    options = [[t("submission_pages.select_option"), ""]]
-                   answer_type.matrix_answer_drop_options.each do |mado|
+                   answer_type.matrix_answer_drop_options.order('id DESC').each do |mado|
                        options += [[h(mado.option_text), mado.id]]
                    end
                 -%>

--- a/app/views/matrix_answers/_preview.html.erb
+++ b/app/views/matrix_answers/_preview.html.erb
@@ -1,6 +1,6 @@
 <% queries_as_rows = answer_type.matrix_orientation == 0 %>
-<% columns = queries_as_rows ? answer_type.matrix_answer_options : answer_type.matrix_answer_queries  -%>
-<% rows = queries_as_rows ? answer_type.matrix_answer_queries : answer_type.matrix_answer_options  -%>
+<% columns = (queries_as_rows ? answer_type.matrix_answer_options : answer_type.matrix_answer_queries).order('id DESC')  -%>
+<% rows = (queries_as_rows ? answer_type.matrix_answer_queries : answer_type.matrix_answer_options).order('id DESC')  -%>
 <% the_id = "matrix_answer_#{answer_type.id}"-%>
 <table class="submission_matrix" style="width: 550px">
   <thead>

--- a/app/views/matrix_answers/_show.html.erb
+++ b/app/views/matrix_answers/_show.html.erb
@@ -26,7 +26,7 @@
 <% if answer_type.display_reply == 3 -%>
     <p>Drop down options</p>
     <ul>
-      <% answer_type.matrix_answer_drop_options.each do |drop_option| -%>
+      <% answer_type.matrix_answer_drop_options.order('id DESC').each do |drop_option| -%>
       <li>
         <%=h drop_option.option_text(language) %>
       </li>

--- a/app/views/matrix_answers/_show.html.erb
+++ b/app/views/matrix_answers/_show.html.erb
@@ -9,7 +9,7 @@
 </p>
 <p>Queries</p>
 <ul>
-  <% answer_type.matrix_answer_queries.each do |query| %>
+  <% answer_type.matrix_answer_queries.order('id DESC').each do |query| %>
       <li>
         <%= h query.title(language) %>
       </li>

--- a/app/views/matrix_answers/_submission.html.erb
+++ b/app/views/matrix_answers/_submission.html.erb
@@ -1,7 +1,7 @@
 <% queries_as_rows = answer_type.matrix_orientation == 0 %>
 <% columns = queries_as_rows ? answer_type.matrix_answer_options.order('id DESC') : answer_type.matrix_answer_queries  -%>
 <% rows = queries_as_rows ? answer_type.matrix_answer_queries : answer_type.matrix_answer_options.order('id DESC')  -%>
-<% drop_down_options = answer_type.matrix_answer_drop_options %>
+<% drop_down_options = answer_type.matrix_answer_drop_options.order('id DESC') %>
 <% selection = {} %>
 <% if answer
     answer.matrix_cells_answers(selection)


### PR DESCRIPTION
Matrix answer queries and drop options were also affected by the ordering issue. This fixes it so that the order of both queries and options are matching the order at creation time