### PR TITLE
Add redis session store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'prawn'
 gem 'htmlentities'
 
 gem 'redis'
+gem 'redis-session-store'
 gem 'sidekiq'
 gem 'sidekiq-status'
 gem 'sinatra', :require => nil

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,6 +260,9 @@ GEM
     redis (3.2.1)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
+    redis-session-store (0.9.1)
+      actionpack (>= 3, < 5.1)
+      redis (~> 3)
     request_store (1.3.2)
     rspec-logsplit (0.1.3)
     rubocop (0.31.0)
@@ -383,6 +386,7 @@ DEPENDENCIES
   rails-secrets
   rake (= 10.0.3)
   redis
+  redis-session-store
   rubocop
   ruby-prof
   sanitize

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -4,6 +4,7 @@
 OnlineReportingTool::Application.config.session_store :redis_session_store, {
   key: '_report_manager_session',
   redis: {
+    expire_after: 3.weeks,
     key_prefix: 'online_reporting_tool:session:',
     url: Rails.application.secrets.redis['url']
   }

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,13 @@
 # Be sure to restart your server when you modify this file.
 
-OnlineReportingTool::Application.config.session_store :cookie_store, key: '_report_manager_session'
+#OnlineReportingTool::Application.config.session_store :cookie_store, key: '_report_manager_session'
+OnlineReportingTool::Application.config.session_store :redis_session_store, {
+  key: '_report_manager_session',
+  redis: {
+    key_prefix: 'online_reporting_tool:session:',
+    url: Rails.application.secrets.redis['url']
+  }
+}
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information


### PR DESCRIPTION
To fix the CookieOverflowError which seems to be trigger if we try to store more than 4KB.
This issues seems to happen only for one party.
This uses the redis-session-store instead. I didn't add any `expire_after` option, might worth considering it maybe?