### PR TITLE
Do not strip < for text answers when generating pdf

### DIFF
--- a/app/reports/questionnaire_pdf.rb
+++ b/app/reports/questionnaire_pdf.rb
@@ -417,7 +417,7 @@ class QuestionnairePdf < Prawn::Document
     #bounding_box [5, cursor], :width => box_width, :height => box_rows do
     span(box_width) do
       if entered_text
-        txt = @coder.decode(OrtSanitize.white_space_cleanse(entered_text))
+        txt = @coder.decode(OrtSanitize.white_space_cleanse(entered_text, false))
         text "› " + txt
       else
         text "›"

--- a/lib/ort_sanitize.rb
+++ b/lib/ort_sanitize.rb
@@ -22,14 +22,16 @@
 
 class OrtSanitize
 
-  def self.white_space_cleanse text_obj
+  def self.white_space_cleanse text_obj, sanitize=true
     if text_obj
       text_obj = text_obj.gsub("<br />", "\n")
       text_obj = text_obj.gsub("\t", " ")
-      sanitized = Sanitize.clean(text_obj, Config::PRAWN)
-      if sanitized
-        return sanitized.gsub(/&#13;$/,"\n").gsub(/&#([0-9]*);$/," ").squeeze(" ").gsub(%r{( )*(\r)+}, "").squeeze("\n").strip
+      if sanitize
+        sanitized = Sanitize.clean(text_obj, Config::PRAWN)
+      else # Used to generate pdf correctly without stripping < for text answers
+        text_obj = text_obj.gsub("<", "&lt;")
       end
+      return (sanitized || text_obj).gsub(/&#13;$/,"\n").gsub(/&#([0-9]*);$/," ").squeeze(" ").gsub(%r{( )*(\r)+}, "").squeeze("\n").strip
     end
     ""
   end
@@ -41,7 +43,8 @@ class OrtSanitize
                     'colgroup', 'dd', 'dl', 'dt', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
                     'i', 'img', 'li', 'ol', 'p', 'pre', 'q', 'small', 'strike', 'strong',
                     'sub', 'sup', 'table', 'tbody', 'td', 'tfoot', 'th', 'thead', 'tr', 'u',
-                    'ul', 'span', 'em'],
+                    'ul', 'span', 'em'
+            ],
 
             :attributes => {
                     'a'          => ['href', 'title', 'target'],
@@ -69,16 +72,14 @@ class OrtSanitize
             }
     }
     PRAWN = {
-      :elements => [
-        'a', 'b', 'h1','i', 'u', 'strong'],
+      :elements => ['a', 'b', 'h1','i', 'u', 'strong'],
 
       :attributes => {
         'a'          => ['href', 'title', 'target']
       },
 
       :protocols => {
-        'a'          => {'href' => ['ftp', 'http', 'https', 'mailto',
-                                    :relative]}
+        'a'          => {'href' => ['ftp', 'http', 'https', 'mailto', :relative]}
       },
       :allowed_entities => ['amp']
     }


### PR DESCRIPTION
This is to fix text answers being truncated when generating a PDF.
The sanitizer strips also non closed tags and this creates an issue. So I've just added a flag to specify when we don't want this to happen and apply that for those answers.
There should be no security issue in doing that, since the pdf will render the &lt; symbol correctly without running any possible script. 