### PR TITLE
Refactor jquery selectors

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -27,4 +27,5 @@
 //= require_tree ./utils
 //= require_tree ./components/users
 //= require_tree ./components/questionnaires
+//= require_tree ./components/loop_items
 //= require_tree ./application

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -28,4 +28,5 @@
 //= require_tree ./components/users
 //= require_tree ./components/questionnaires
 //= require_tree ./components/loop_items
+//= require_tree ./components/loop_sources
 //= require_tree ./application

--- a/app/assets/javascripts/components/loop_items.js
+++ b/app/assets/javascripts/components/loop_items.js
@@ -1,0 +1,1 @@
+//require loop_items/base

--- a/app/assets/javascripts/components/loop_items/base.js.coffee
+++ b/app/assets/javascripts/components/loop_items/base.js.coffee
@@ -1,0 +1,24 @@
+window.LoopItemsComponent = class LoopItemsComponent
+  @initialize: ->
+    @addEventListeners()
+
+  @addEventListeners: ->
+    @itemNamesTable()
+
+  @itemNamesTable: ->
+    $("#item_names_table").on("click","#add_item_name_other_languages", (e) ->
+        e.preventDefault()
+        $("#add_extra").hide('slow').empty()
+        $("#add_extra_source").hide('slow').empty()
+        $("#add_loop_item_names_source").show('slow')
+    )
+    $("#hide_add_translations").click( (e) ->
+        e.preventDefault()
+        $("#add_loop_item_names_source").hide('slow')
+    )
+    $("#item_names_table").tablesorter({
+        sortList: [[0,0]],
+        widgets: ['zebra']
+    })
+
+$(document).ready -> LoopItemsComponent.initialize()

--- a/app/assets/javascripts/components/loop_sources.js
+++ b/app/assets/javascripts/components/loop_sources.js
@@ -1,0 +1,1 @@
+//require loop_sources/base

--- a/app/assets/javascripts/components/loop_sources/base.js.coffee
+++ b/app/assets/javascripts/components/loop_sources/base.js.coffee
@@ -1,0 +1,14 @@
+window.LoopSourcesComponent = class LoopSourcesComponent
+  @initialize: ->
+    @addEventListeners()
+
+  @addEventListeners: ->
+    @updateSource()
+
+  @updateSource: ->
+    $("#update_source").click( (e) ->
+      e.preventDefault()
+      $("#edit_source").toggle('slow')
+    )
+
+$(document).ready -> LoopSourcesComponent.initialize()

--- a/app/assets/javascripts/components/questionnaires/base.js.coffee
+++ b/app/assets/javascripts/components/questionnaires/base.js.coffee
@@ -9,6 +9,7 @@ window.QuestionnairesComponent = class QuestionnairesComponent
     @hideInfoContent()
     @addCloseEvent()
     @addHideInfoEvent()
+    @slideDuplicateQuestionnaire()
 
   @hideInfoContent: ->
     $('.app-content').on('click', '.info-toggle-header', (ev) ->
@@ -51,6 +52,22 @@ window.QuestionnairesComponent = class QuestionnairesComponent
       if toggle_info.text().indexOf("Hide") != 1
         toggle_info.text("Show")
     )
+
+  @slideDuplicateQuestionnaire: ->
+    $("#questionnaire_original_id").change( ->
+        val = $(@).val()
+        closedAny = false
+        $(".questionnaires_info").each( ->
+          if($(@).is(":visible"))
+            $(@).slideUp("slow", ->
+              $("#questionnaire_"+val).slideDown("slow")
+            )
+            closedAny = true
+        )
+        if(!closedAny)
+          $("#questionnaire_"+val).slideDown("slow")
+    )
+
 
 $(document).ready -> QuestionnairesComponent.initialize()
 

--- a/app/assets/javascripts/components/users/base.js.coffee
+++ b/app/assets/javascripts/components/users/base.js.coffee
@@ -1,5 +1,6 @@
 window.UsersComponent = class UsersComponent
   @initialize: ->
+    UsersComponent.UserDelegates.initialize()
     @addEventListeners()
 
   @addEventListeners: ->

--- a/app/assets/javascripts/components/users/user_delegates.js.coffee
+++ b/app/assets/javascripts/components/users/user_delegates.js.coffee
@@ -1,0 +1,21 @@
+window.UsersComponent.UserDelegates = class UsersComponent.UserDelegates
+  @initialize: ->
+    @addEventListeners()
+
+  @addEventListeners: ->
+    @showDetails()
+    @delegatedTasksTable()
+
+  @showDetails: ->
+    $(".show-details").click( (e) ->
+      e.preventDefault()
+      $(@).parent().siblings('.delegation-details').toggle('slow')
+    )
+
+  @delegatedTasksTable: ->
+    $("#delegated_tasks_table").tablesorter({
+      sortList: [[0,0]],
+      widgets: ['zebra']
+    })
+
+

--- a/app/assets/javascripts/utils/layout.js.coffee
+++ b/app/assets/javascripts/utils/layout.js.coffee
@@ -1,0 +1,12 @@
+window.Layout = class Layout
+  @initialize: ->
+    @addEventListeners()
+
+  @addEventListeners: ->
+    $("#display_language").change( ->
+      selected_lang = $(@).val()
+      if(selected_lang != "")
+        window.location = "?lang=#{selected_lang}"
+    )
+
+$(document).ready -> Layout.initialize()

--- a/app/views/layouts/_authentication.html.erb
+++ b/app/views/layouts/_authentication.html.erb
@@ -9,15 +9,6 @@
     <%= link_to t("login_menu.login"), root_path(:lang => (params[:lang]||"en")) %>
   </p>
   <p style="float: right">
-    <%= select :display, :language, [["English","en"], ["Français","fr"]], {:selected => (params[:lang] || "en")}  %> 
+    <%= select :display, :language, [["English","en"], ["Français","fr"]], {:selected => (params[:lang] || "en")}  %>
   </p>
-  <script type="text/javascript">
-    $("#display_language").change(function(){
-      var selected_lang = $(this).val();
-      if(selected_lang != "")
-      {
-        window.location = "?lang="+selected_lang;
-      }
-    });
-  </script>
   <% end -%>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,14 +13,6 @@
           <% end %>
           <%= link_to t("login_menu.login"), root_path(:lang => (params[:lang]||"en")) %>
           | <%= select :display, :language, [["English","en"], ["Français","fr"], ["Español","es"]], {:selected => (params[:lang] || "en")}  %>
-          <script type="text/javascript">
-            $("#display_language").change(function(){
-              var selected_lang = $(this).val();
-              if(selected_lang != ""){
-                window.location = "?lang="+selected_lang;
-              }
-            });
-          </script>
         <% end %>
       </p>
     </div>

--- a/app/views/loop_item_types/show.html.erb
+++ b/app/views/loop_item_types/show.html.erb
@@ -143,19 +143,3 @@
     </table>
   </div>
 </div>
-<script type="text/javascript">
-    $("#item_names_table").on("click","#add_item_name_other_languages", function(e){
-        e.preventDefault();
-        $("#add_extra").hide('slow').empty();
-        $("#add_extra_source").hide('slow').empty();
-        $("#add_loop_item_names_source").show('slow');
-    });
-    $("#hide_add_translations").click(function(e){
-        e.preventDefault();
-        $("#add_loop_item_names_source").hide('slow');
-    });
-    $("#item_names_table").tablesorter({
-        sortList: [[0,0]],
-        widgets: ['zebra']
-    });
-</script>

--- a/app/views/questionnaires/duplicate.html.erb
+++ b/app/views/questionnaires/duplicate.html.erb
@@ -71,22 +71,3 @@
     <% end -%>
   </div>
 </div>
-<script type="text/javascript">
-    $(function(){
-        $("#questionnaire_original_id").change(function(){
-            var val = $(this).val();
-            var closedAny = false;
-            $(".questionnaires_info").each(function(){
-                if($(this).is(":visible"))
-                {
-                    $(this).slideUp("slow", function(){
-                        $("#questionnaire_"+val).slideDown("slow");
-                    });
-                    closedAny = true;
-                }
-            });
-            if(!closedAny)
-                $("#questionnaire_"+val).slideDown("slow");
-        })
-    })
-</script>

--- a/app/views/source_files/edit.html.erb
+++ b/app/views/source_files/edit.html.erb
@@ -49,9 +49,3 @@
     <% end -%>
   </div>
 </div>
-<script type="text/javascript">
-    $("#update_source").click(function(e){
-        e.preventDefault();
-        $("#edit_source").toggle('slow');
-    })
-</script>

--- a/app/views/user_delegates/show.html.erb
+++ b/app/views/user_delegates/show.html.erb
@@ -62,7 +62,7 @@
         <% if delegation.sections.present? %>
           <div class="delegation-details hide" id="delegation_details_<%= delegation.id %>">
             <table>
-              <thead>
+              <thead
                 <tr>
                   <th><%= t('generic.section')%></th>
                   <th><%= t('delegation_details.root_section_th')%></th>
@@ -87,15 +87,3 @@
   </div>
 <% end %>
 </div><!-- /content -->
-<script type="text/javascript">
-  $(function(){
-      $(".show-details").click(function(e){
-        e.preventDefault();
-        $(this).parent().siblings('.delegation-details').toggle('slow');
-      });
-      $("#delegated_tasks_table").tablesorter({
-        sortList: [[0,0]],
-        widgets: ['zebra']
-      });
-    });
-</script>


### PR DESCRIPTION
So, this is a first of many series of improvements to the ORS views and javascript.
The `remove-js-from-views` branch has been created starting from master, and all the tasks (including this one) regarding the javascript refactoring should be merged in there.

In this PR I refactored the easiest of the javascript which was still in the views; it's mainly about selectors and events and I have moved those into new or already existing coffeescripts components.

I believe that at a certain stage we should also consider using a javascript framework (possibly React), because the other bits of javascript are quite complicated to refactor and need interaction with the backend as well.