### PR TITLE
Fix file check in CSV generator

### DIFF
--- a/app/workers/questionnaire_to_csv.rb
+++ b/app/workers/questionnaire_to_csv.rb
@@ -14,7 +14,10 @@ class QuestionnaireToCsv
     end
     file_location << "questionnaire_generating.csv"
 
-    if File.exist?(file_location) && File.atime(file_location) < 30.minutes.ago
+    # stop here if a "questionnaire_generating.csv" file is found, created less than
+    # 30 minutes ago. This means that an import is already running, and we shouldn't
+    # start another one
+    if File.exist?(file_location) && File.atime(file_location) > 30.minutes.ago
       return false
     end
 

--- a/app/workers/questionnaire_to_csv.rb
+++ b/app/workers/questionnaire_to_csv.rb
@@ -3,15 +3,13 @@ class QuestionnaireToCsv
   sidekiq_options queue: "low"
 
   def perform(user_id, questionnaire_id, separator)
-    user = User.find(user_id)
+    user          = User.find(user_id)
     questionnaire = Questionnaire.find(questionnaire_id)
-
     return if !user || !questionnaire
 
     file_location = "#{Rails.root}/private/questionnaires/#{questionnaire.id.to_s}/"
-    if !File.directory? file_location
-      FileUtils.mkdir_p(file_location)
-    end
+    FileUtils.mkdir_p(file_location) if !File.directory?(file_location)
+
     file_location << "questionnaire_generating.csv"
 
     # stop here if a "questionnaire_generating.csv" file is found, created less than
@@ -25,12 +23,13 @@ class QuestionnaireToCsv
       CsvMethods.fill_csv file_location, questionnaire.submitters, questionnaire.sections, separator
 
       # move file to the final destination
-      file_record = questionnaire.csv_file || CsvFile.new(:entity => questionnaire)
+      file_record = questionnaire.csv_file || CsvFile.new(entity: questionnaire)
       if !file_record.new_record? && File.exist?(file_record.location)
         FileUtils.rm(file_record.location)
       end
+
       file_record.name = questionnaire.title[0,35].gsub(/[^a-z0-9\-]+/i, '_') + "_#{DateTime.now.strftime("%d%m%Y")}.csv"
-      file_record.location = "private/questionnaires/#{questionnaire.id.to_s}/"+ file_record.name
+      file_record.location = "private/questionnaires/#{questionnaire.id.to_s}/" + file_record.name
       file_record.save
 
       FileUtils.move(file_location, file_record.location)
@@ -40,11 +39,11 @@ class QuestionnaireToCsv
       UserMailer.csv_file_generated(user, questionnaire).deliver
     rescue => e
       UserMailer.csv_generation_failed(user, questionnaire, e).deliver
-      if File.exists?(file_location)
-        FileUtils.rm(file_location)
-      end
+      FileUtils.rm(file_location) if File.exists?(file_location)
+
       Appsignal.add_exception(e)
     end
+
     true
   end
 end


### PR DESCRIPTION
This PR fixes an issue discovered in the questionnaire CSV generation, which occurs when previously unsuccessful imports are retried, after at least 30 minutes. 

```diff
-  if File.exist?(file_location) && File.atime(file_location) < 30.minutes.ago
+  if File.exist?(file_location) && File.atime(file_location) > 30.minutes.ago
```

