### PR TITLE
Constraint on delegate creation

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -71,7 +71,6 @@ class UsersController < ApplicationController
 
     if validate_delegations && @user.save
       @user.add_or_update_filtering_fields(params[:filtering_field]) if params[:filtering_field]
-      #@user.add_delegations(get_user_delegates_params) assign delegations through user model
       @user.update_attributes(get_user_delegators_params) if @user.role?(:delegate)
       url = "http://#{request.host}/"
       UserMailer.user_registration(@user, params[:user][:password], url).deliver

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -197,7 +197,7 @@ class UsersController < ApplicationController
     delegators = get_user_delegators_params[:user_delegators_attributes]
     if delegators.present?
       empty_questionnaires = delegators.select do |key, attrs|
-        !attrs["delegations_attributes"]["0"]["questionnaire_id"].present?
+        attrs["delegations_attributes"]["0"]["questionnaire_id"].blank?
       end
       return true unless empty_questionnaires.present?
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -69,7 +69,7 @@ class UsersController < ApplicationController
     @user              = User.new(delegators_params)
     @user.creator_id   = current_user.id
 
-    if @user.save
+    if validate_delegations && @user.save
       @user.add_or_update_filtering_fields(params[:filtering_field]) if params[:filtering_field]
       #@user.add_delegations(get_user_delegates_params) assign delegations through user model
       @user.update_attributes(get_user_delegators_params) if @user.role?(:delegate)
@@ -84,7 +84,8 @@ class UsersController < ApplicationController
     else
       respond_to do |format|
         format.html {
-          render :action => "new", :params => {:lang => (params[:lang]||"en")}
+          flash[:error] = flash[:error]
+          render :action => "add_new_user", :params => {:lang => (params[:lang]||"en")}
         }
       end
     end
@@ -189,5 +190,18 @@ class UsersController < ApplicationController
         value['user_id'].present? && value.merge!(delegate_id: @user.id)
       end
     {user_delegators_attributes: user_delegators_attributes}
+  end
+
+  def validate_delegations
+    return true unless @user.role? :delegate
+    delegators = get_user_delegators_params[:user_delegators_attributes]
+    if delegators.present?
+      empty_questionnaires = delegators.select do |key, attrs|
+        !attrs["delegations_attributes"]["0"]["questionnaire_id"].present?
+      end
+      return true unless empty_questionnaires.present?
+    end
+    flash[:error] = "No delegations assigned for delegate user"
+    return false
   end
 end

--- a/app/models/delegation.rb
+++ b/app/models/delegation.rb
@@ -11,7 +11,7 @@ class Delegation < ActiveRecord::Base
   has_many :delegated_loop_item_names, :through => :delegation_sections
   has_many :loop_item_names, :through => :delegated_loop_item_names, :include => :loop_item_name_fields
 
-  attr_accessible :questionnaire_id
+  attr_accessible :questionnaire_id, :user_delegate_id
 
   validates :questionnaire_id, presence: true
 

--- a/app/views/users/_delegations.html.erb
+++ b/app/views/users/_delegations.html.erb
@@ -17,7 +17,7 @@
       </thead>
       <tbody>
         <% User.submitters.each do |user| %>
-          <%= f.fields_for :user_delegators, @user.user_delegators do |ff| %>
+          <%= f.fields_for :user_delegators, @user.user_delegators.build do |ff| %>
             <tr id="row_<%=user.id.to_s%>">
               <td><%= ff.check_box :user_id, {class: "checkboxes" }, user.id, ''%></td>
               <td><%= link_to h(user.full_name), user_path(user) %></td>


### PR DESCRIPTION
The aim is to prevent the Admin to create a delegate without assigning at least one respondent to it.
We can't do this at the model level since we are working with convoluted nested attributes and we need the id of the user we are just generating; everything has been validated at the controller level then.

This also fixes some minor bugs about the rendering of the respondents list and the access to the delegation page.