### PR TITLE
Super delegate features

### DIFF
--- a/app/assets/javascripts/components/users/base.js.coffee
+++ b/app/assets/javascripts/components/users/base.js.coffee
@@ -24,11 +24,16 @@ window.UsersComponent = class UsersComponent
     )
 
   @respondentsTable: ->
+    that = @
     $('.delegate-box, .super_delegate-box').on('click', ->
-      if $(@).attr('checked')
+      if $(@).attr('checked') || that.delegateBoxChecked()
         $('.respondents-list').slideDown()
       else
         $('.respondents-list').slideUp()
     )
+
+  @delegateBoxChecked: ->
+    $('.delegate-box').attr('checked') || $('.super_delegate-box').attr('checked')
+
 
 $(document).ready -> UsersComponent.initialize()

--- a/app/assets/javascripts/components/users/base.js.coffee
+++ b/app/assets/javascripts/components/users/base.js.coffee
@@ -24,7 +24,7 @@ window.UsersComponent = class UsersComponent
     )
 
   @respondentsTable: ->
-    $('.delegate-box').on('click', ->
+    $('.delegate-box, .super_delegate-box').on('click', ->
       if $(@).attr('checked')
         $('.respondents-list').slideDown()
       else

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,7 +4,7 @@ class HomeController < ApplicationController
     if current_user
       if current_user.role?(:respondent)
         @questionnaires = Questionnaire.authorized_questionnaires(current_user)
-      elsif current_user.role?(:delegate)
+      elsif current_user.is_delegate?
         redirect_to dashboard_user_delegate_path(current_user.id)
       end
     else

--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -232,7 +232,7 @@ class QuestionnairesController < ApplicationController
   def submission
     @authorization = current_user ? current_user.authorization_for(@questionnaire) : false
     raise CanCan::AccessDenied.new(t("flash_messages.#{@authorization ? @authorization[:error_message] : "not_authorized"}"), :submission, Questionnaire) if !@authorization || @authorization[:error_message]
-    if current_user.role?(:delegate)
+    if current_user.is_delegate?
       @delegation = current_user.delegated_tasks.find_by_questionnaire_id(@questionnaire.id)
     end
     @sections_to_display_in_tab = @questionnaire.sections_to_display_in_tab.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -71,7 +71,7 @@ class UsersController < ApplicationController
 
     if validate_delegations && @user.save
       @user.add_or_update_filtering_fields(params[:filtering_field]) if params[:filtering_field]
-      @user.update_attributes(get_user_delegators_params) if @user.role?(:delegate)
+      @user.update_attributes(get_user_delegators_params) if @user.is_delegate?
       url = "http://#{request.host}/"
       UserMailer.user_registration(@user, params[:user][:password], url).deliver
       respond_to do |format|
@@ -192,7 +192,7 @@ class UsersController < ApplicationController
   end
 
   def validate_delegations
-    return true unless @user.role? :delegate
+    return true if (@user.role?(:respondent) || @user.role?(:admin))
     delegators = get_user_delegators_params[:user_delegators_attributes]
     if delegators.present?
       empty_questionnaires = delegators.select do |key, attrs|

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -10,7 +10,7 @@ class Ability
       can :create, User do
         user.id.nil?
       end
-      if user.role?(:respondent) || user.role?(:delegate)
+      if user.role?(:respondent) || user.is_delegate?
         can :submission, Questionnaire do |questionnaire|
           user.authorized_to_answer? questionnaire
         end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -113,7 +113,7 @@ class Answer < ActiveRecord::Base
       question_id, looping_identifier, field_id, extra_val = identifiers.split("_")
       looping_identifier = nil if !looping_identifier.present? || looping_identifier == "0"
       question = Question.find(question_id)
-      if user.id != editor.id && question.answer_type_type == "TextAnswer"
+      if ((user.id != editor.id && !editor.role?(:super_delegate)) && question.answer_type_type == "TextAnswer")
         auth_error = true
         next
       end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -210,6 +210,7 @@ class Question < ActiveRecord::Base
   end
 
   def can_edit_text_answer? answer, user_delegate
+    return true if user_delegate.present? && user_delegate.delegate.role?(:super_delegate)
     !((self.answer_type_type == 'TextAnswer' && user_delegate.present?) || (answer && answer.question_answered))
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -102,7 +102,7 @@ class User < ActiveRecord::Base
       authorization = AuthorizedSubmitter.find_by_questionnaire_id_and_user_id(questionnaire.id, self.id)
       return authorization if authorization
     end
-    if !authorization && self.role?(:delegate)
+    if !authorization && is_delegate?
       delegation = user_delegate.present? ? self.delegated_tasks.find_by_questionnaire_id_and_user_delegate_id(questionnaire.id, user_delegate) : self.delegated_tasks.find_by_questionnaire_id(questionnaire.id)
       return false if !delegation
       return delegation.user.authorized_to_answer?(questionnaire)
@@ -145,7 +145,7 @@ class User < ActiveRecord::Base
     authorization[:language_full_name] = aux.language_full_name
     authorization[:user] = aux.user
     #get the delegation details if the user is a delegate and it has been delegated with this questionnaire
-    if self.role?(:delegate)
+    if is_delegate?
       #no check for the existence of delegation, because that is checked in the 'is_authorized_to_answer?' method
       delegation = user_delegate ? self.delegated_tasks.find_by_questionnaire_id_and_user_delegate_id(questionnaire, user_delegate) : self.delegated_tasks.find_by_questionnaire_id(questionnaire)
       #if the sections aren't defined the delegate can answer the whole questionnaire
@@ -370,6 +370,10 @@ class User < ActiveRecord::Base
       questionnaire_id = value["delegations_attributes"].first["questionnaire_id"]
       Delegation.create(questionnaire_id: questionnaire_id, user_delegate_id: user_delegate.id)
     end
+  end
+
+  def is_delegate?
+    role?(:delegate) || role?(:super_delegate)
   end
 
   private

--- a/app/views/questions/_answer_details.html.erb
+++ b/app/views/questions/_answer_details.html.erb
@@ -12,7 +12,7 @@
   <% if answer -%>
     <p class="tooltips">
       Answered by:
-      <% editor = answer.user %>
+      <% editor = answer.last_editor %>
       <span><%= editor.id != current_user.id ? (link_to h(editor.full_name)[0,30], user_path(editor), :title => h(editor.full_name)) : 'You' -%></span>
       <span>(<%= answer.updated_at %>)</span>
     </p>

--- a/app/views/text_answers/_delegate_text_answers.html.erb
+++ b/app/views/text_answers/_delegate_text_answers.html.erb
@@ -1,5 +1,5 @@
 <% unique_id = append_identifier(question, looping_identifier) %>
-<% if answer %>
+<% if answer && !current_user.role?(:super_delegate) %>
   <%= hidden_field_tag "delegate_text_answers[#{unique_id}][answer_id]", answer.id, class: 'disabled_section_information' %>
   <% delegate_text_answers = answer.delegate_text_answers.order('updated_at DESC') %>
   <% delegate_answers_div = false %>


### PR DESCRIPTION
This is about making the Super Delegate role to work as the delegate one, with the exception that the Super Delegate can override the Respondent's text answer (A normal delegate has a dedicated box for her/his own text answer, so she/he can't override the Respondent's one).

Also, the last editor of an answer should always be the one displayed in the Answer By section below the answer area.
