### PR TITLE
Fix incorrect documents showing as attached

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -30,7 +30,8 @@ class AnswersController < ApplicationController
     @authorization = current_user ? current_user.authorization_for(@question, @current_user_delegate.try(:id)) : false
     raise CanCan::AccessDenied.new(t("flash_messages.#{@authorization ? @authorization[:error_message] : "not_authorized"}")) if !@authorization || @authorization[:error_message]
     I18n.locale = @authorization[:language]
-    @answer = Answer.find_or_create_by_question_id_and_questionnaire_id_and_user_id_and_looping_identifier(@question.id, @question.section.root.questionnaire.id, @authorization[:user].id, params[:looping_identifier])
+    user_id = params[:respondent_id] || @authorization[:user].id
+    @answer = Answer.find_or_create_by_question_id_and_questionnaire_id_and_user_id_and_looping_identifier(@question.id, @question.section.root.questionnaire.id, user_id, params[:looping_identifier])
     @answer.documents.build
     respond_to do |format|
       format.js
@@ -42,7 +43,8 @@ class AnswersController < ApplicationController
     @authorization = current_user ? current_user.authorization_for(@question, @current_user_delegate.try(:id)) : false
     raise CanCan::AccessDenied.new(t("flash_messages.#{@authorization ? @authorization[:error_message] : "not_authorized"}")) if !@authorization || @authorization[:error_message]
     I18n.locale = @authorization[:language]
-    @answer = Answer.find_or_create_by_question_id_and_questionnaire_id_and_user_id_and_looping_identifier(@question.id, @question.section.root.questionnaire.id, @authorization[:user].id, params[:looping_identifier])
+    user_id = params[:respondent_id] || @authorization[:user].id
+    @answer = Answer.find_or_create_by_question_id_and_questionnaire_id_and_user_id_and_looping_identifier(@question.id, @question.section.root.questionnaire.id, user_id, params[:looping_identifier])
     @answer.answer_links.build
     respond_to do |format|
       format.js

--- a/app/views/questions/_answer_details.html.erb
+++ b/app/views/questions/_answer_details.html.erb
@@ -3,9 +3,9 @@
     <% if answer_type_help_text -%>
       <%= tooltip((field_to_use && field_to_use.short_title ? field_to_use.short_title : ""), answer_type_help_text) %> <% end -%>
     <% if question.allow_attachments? -%>
-      <%= link_to fa_icon('paperclip', alt: 't("submission_pages.attach_files")) + " " + t("submission_pages.attach_files")', class: 'background inverse info'), add_document_answer_path(question, :looping_identifier => looping_identifier, :user_delegate => @current_user_delegate.try(:id)), :class => "get" %>
+      <%= link_to fa_icon('paperclip', alt: 't("submission_pages.attach_files")) + " " + t("submission_pages.attach_files")', class: 'background inverse info'), add_document_answer_path(question, looping_identifier: looping_identifier, user_delegate: @current_user_delegate.try(:id), respondent_id: params[:respondent_id]), :class => "get" %>
 
-      <%= link_to fa_icon('link', alt: "t('submission_pages.attach_links')", class: 'background inverse info'), add_links_answer_path(question, :looping_identifier => looping_identifier, :user_delegate => @current_user_delegate.try(:id)), :class => "get" %>
+      <%= link_to fa_icon('link', alt: "t('submission_pages.attach_links')", class: 'background inverse info'), add_links_answer_path(question, looping_identifier: looping_identifier, user_delegate: @current_user_delegate.try(:id), respondent_id: params[:respondent_id]), :class => "get" %>
     <% end -%>
   </div>
 


### PR DESCRIPTION
As an admin and looking to a respondent's instance of a questionnaire, you could see wrong attached documents coming from yourself rather then other respondents.