### PR TITLE
Disable duplicate questionnaire

### DIFF
--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -324,7 +324,9 @@ class QuestionnairesController < ApplicationController
   end
 
   def duplicate
-    @questionnaires = Questionnaire.find(:all, :include => [:questionnaire_fields, :user, :questionnaire_parts ])
+    # Temporarily disable questionnaire duplication for
+    # questionnaires which have already been created from another one.
+    @questionnaires = Questionnaire.includes(:questionnaire_fields, :user, :questionnaire_parts).where(original_id: nil)
     @questionnaire = Questionnaire.new
     respond_to do |format|
       format.html

--- a/app/views/questionnaires/duplicate.html.erb
+++ b/app/views/questionnaires/duplicate.html.erb
@@ -8,6 +8,9 @@
   <div id="content_header">
   <% info_tip_text = "<p>This page allows you to create new questionnaires from existing questionnaires. There is an option to copy not only the structure of the questionnaire, but its answers as well.</p>"-%>
   </div>
+  <p>
+    <%= fa_icon('info-circle', class: 'info-icon--blue') %> ORS does not currently support duplication of questionnaires that have already been duplicated. Please contact <a href="mailto:ORS_team@unep-wcmc.org">ORS_team@unep-wcmc.org</a> for more information.
+  </p>
   <div class="span-15 colborder" id="duplicate_questionnaire">
     <%= form_for( @questionnaire, :html => { :class => "formtastic normal", :id => "generator_form" }) do |f| -%>
         <fieldset>

--- a/app/workers/clone_questionnaire.rb
+++ b/app/workers/clone_questionnaire.rb
@@ -6,7 +6,11 @@ class CloneQuestionnaire
     user = User.find(user_id)
     questionnaire = Questionnaire.find(questionnaire_id)
 
-    return if !user || !questionnaire
+    # Temporarily disable questionnaire duplication for
+    # questionnaires which have already been created from another one.
+    has_source_questionnaire = questionnaire.original_id.present?
+
+    return if !user || !questionnaire || has_source_questionnaire
 
     logger = Logger.new("#{Rails.root}/log/sidekiq.log")
     logger.info("#{Time.now}: Started duplication of questionnaire with#{if !copy_answers || copy_answers != "1" then "out" end} answers: #{questionnaire.title}")


### PR DESCRIPTION
## Description

Disable the duplicate questionnaire functionality for questionnaires that are already a result of a first duplication.
That is because the functionality is buggy only on that case.

I've excluded those questionnaires from the list of available ones when using the duplicate functionality, made sure that it cannot be triggered and also notified the user about that.