### PR TITLE
Fetch original document on cloned questionnaires 

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -4,6 +4,10 @@ class DocumentsController < ApplicationController
     answer = Answer.find(params[:answer_id], :include => :questionnaire)
     raise CanCan::AccessDenied.new("You are not authorized to download this document", :show, Document) if answer.questionnaire.private_documents && !current_user # answer.user != current_user || answer.last_editor != current_user
     document = answer.documents.find(params[:id])
+    # If document doesn't exist in filesystem, this probably means
+    # the questionnaire has been cloned from another one and here there's
+    # still the original file to be fetched.
+    document = document.original unless File.exists?(document.doc.path)
     send_file document.doc.path, :type => document.doc_content_type
   end
 end


### PR DESCRIPTION
## Description

* Fetch original document if document from cloned questionnaire doesn't exist

## Notes

The same kind of fix has been previously applied to PDF exports