### PR TITLE
Documents size and error message

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -21,7 +21,7 @@ class AnswersController < ApplicationController
       message = if error[0].match(/doc_file_size/).present?
                   # Improve paperclip's standard error message to show size in MB
                   size = error[1].match(/\d+/).to_s.to_i / 1000000
-                  "File's size must be less than #{size} MB."
+                  t('flash_messages.file_too_large', size: size)
                 else
                   "There was a problem when saving your changes, please try again."
                 end

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -17,7 +17,15 @@ class AnswersController < ApplicationController
       flash[:notice] = "Changes successfully made."
       @success = true
     else
-      flash[:error] = "There was a problem when saving your changes, please try again."
+      error = @answer.errors.first #array[0] -> type, array[1] -> desc
+      message = if error[0].match(/doc_file_size/).present?
+                  # Improve paperclip's standard error message to show size in MB
+                  size = error[1].match(/\d+/).to_s.to_i / 1000000
+                  "File's size must be less than #{size} MB."
+                else
+                  "There was a problem when saving your changes, please try again."
+                end
+      flash[:error] = message
       @success = false
     end
     respond_to do |format|

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -21,7 +21,7 @@ class Document < ActiveRecord::Base
                     :path => ":rails_root/private/answer_docs/:questionnaire_id/answer_documents/:user_id/:id/:basename.:extension" #:id_partition
 
   validates_attachment_presence :doc
-  validates_attachment_size :doc, :less_than => 3.megabytes
+  validates_attachment_size :doc, :less_than => 10.megabytes
   do_not_validate_attachment_file_type :doc
 end
 

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -1,4 +1,4 @@
-# Arabic translations for Ruby on Rails 
+# Arabic translations for Ruby on Rails
 # by Rida Al Barazi (me@rida.me)
 # updated by Ahmed Hazem (nardgo@gmail.com)
 
@@ -17,18 +17,18 @@ ar:
       - :day
       - :month
       - :year
-  
+
   time:
     formats:
       default: "%a %b %d %H:%M:%S %Z %Y"
       short: "%d %b %H:%M"
       long: "%B %d, %Y %H:%M"
       only_second: "%S"
-      
+
       datetime:
         formats:
           default: "%Y-%m-%dT%H:%M:%S%Z"
-          
+
     am: 'صباحا'
     pm: 'مساءا'
 
@@ -37,7 +37,7 @@ ar:
     array:
       sentence_connector: "و"
       skip_last_comma: false
-      
+
   datetime:
     distance_in_words:
       half_a_minute: 'نصف دقيقة'
@@ -71,7 +71,7 @@ ar:
       over_x_years:
         one: 'أكثر من سنة'
         other: '{{count}} سنوات'
-      
+
   number:
     format:
       separator: '.'
@@ -94,9 +94,16 @@ ar:
     precision:
       format:
         delimiter: ','
-        
+
   activerecord:
     errors:
+      #PaperClip
+      models:
+        document:
+          attributes:
+            doc_file_size:
+              less_than: "%{max}"
+      #end Paperclip
       template:
         header:
           one: "ليس بالامكان حفظ {{model}}: خطأ واحد."
@@ -122,3 +129,27 @@ ar:
         less_than_or_equal_to: "يجب أن يكون أصغر من أو يساوي {{count}}"
         odd: "يجب أن يكون فردي"
         even: "يجب أن يكون زوجي"
+
+  #Paperclip
+  errors:
+    messages:
+      in_between: "يجب أن يكون %{min} و %{max}"
+      spoofed_media_type: "يحتوي على محتوى غير مطابق عما هو مذكور"
+
+  number:
+    human:
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            zero: "بايت"
+            one: "واحد بايت"
+            two: "بايتين اثنين"
+            few: "بايت"
+            many: "بايتًا"
+            other: "بايتات"
+            kb: "كيلوبايت"
+            mb: "ميحابايت"
+            gb: "غيغابايت"
+            tb: "تيرابايت"
+  #end Paperclip

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -185,6 +185,7 @@ en:
     questionnaire_submitted: "You can not access this page because you have already submitted this questionnaire."
     questionnaire_closed: "This questionnaire has been closed by the administrator so it is currently unavailable."
     questionnaire_not_available: "This questionnaire is not available."
+    file_too_large: "File's size must be less than %{size} MB. (File size can be reduced by compressing (zipping) files prior to upload.)"
   translator_feat:
     show_translator: "Show translator"
     hide_translator: "Hide translator"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -179,6 +179,7 @@ es:
     questionnaire_submitted: "No puede acceder a esta página; ya ha enviado este cuestionario."
     questionnaire_closed: "Este cuestionario no está disponible en este momento; el administrador lo ha cerrado."
     questionnaire_not_available: "Este cuestionario no está disponible."
+    file_too_large: "El tamaño del archivo debe ser inferior a %{size} MB. (El tamaño del archivo puede reducirse comprimiendo (zip) los archivos antes de cargarlos.)"
   translator_feat:
     show_translator: "Mostrar traductor"
     hide_translator: "Ocultar traductor"
@@ -396,3 +397,30 @@ es:
     formats:
       default: "%d %B %Y"
       with_time: "%d %B %Y, %H:%M"
+  #Paperclip
+  errors:
+    messages:
+      in_between: "debe estar entre %{min} y %{max}"
+      spoofed_media_type: "tiene una extensión que no coincide con su contenido"
+
+  number:
+    human:
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: "Byte"
+            other: "Bytes"
+            kb: "KB"
+            mb: "MB"
+            gb: "GB"
+            tb: "TB"
+
+  activerecord:
+    errors:
+      models:
+        document:
+          attributes:
+            doc_file_size:
+              less_than: "El tamaño del archivo debe ser inferior a %{max}"
+  #end Paperclip

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -181,6 +181,7 @@ fr:
     questionnaire_submitted: "Vous ne pouvez pas accéder à cette page car vous avez déjà soumis ce questionnaire."
     questionnaire_closed: "Ce questionnaire a été clos par l'administrateur. Il n'est donc pas disponible pour le moment."
     questionnaire_not_available: "Ce questionnaire n'est pas disponible."
+    file_too_large: "La taille du fichier doit être inférieure à %{size} Mo. (La taille du fichier peut être réduite en comprimant (zippant) les fichiers avant de télécharger.)"
   translator_feat:
     show_translator: "Afficher le traducteur"
     hide_translator: "Masquer le traducteur"
@@ -398,3 +399,30 @@ fr:
     formats:
       default: "%d %B %Y"
       with_time: "%d %B %Y, %H:%M"
+  #Paperclip
+  errors:
+    messages:
+      in_between: "doit être compris entre %{min} et %{max}"
+      spoofed_media_type: "ne correspond pas à ce que cela devrait être"
+
+  number:
+    human:
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: "Octet"
+            other: "Octets"
+            kb: "ko"
+            mb: "Mo"
+            gb: "Go"
+            tb: "To"
+
+  activerecord:
+    errors:
+      models:
+        document:
+          attributes:
+            doc_file_size:
+              less_than: "La taille du fichier doit être inférieure à %{max}"
+  #end Paperclip

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -2,11 +2,11 @@
 # by Yaroslav Markin <yaroslav@markin.net>
 #
 # Be sure to check out "russian" gem (http://github.com/yaroslav/russian) for
-# full Russian language support in Rails (month names, pluralization, etc). 
+# full Russian language support in Rails (month names, pluralization, etc).
 # The following is an excerpt from that gem.
 #
-# Для полноценной поддержки русского языка (варианты названий месяцев, 
-# плюрализация и так далее) в Rails 2.2 нужно использовать gem "russian" 
+# Для полноценной поддержки русского языка (варианты названий месяцев,
+# плюрализация и так далее) в Rails 2.2 нужно использовать gem "russian"
 # (http://github.com/yaroslav/russian). Следующие данные -- выдержка их него, чтобы
 # была возможность минимальной локализации приложения на русский язык.
 
@@ -46,7 +46,7 @@ ru:
       separator: "."
       delimiter: " "
       precision: 3
-      
+
     currency:
       format:
         format: "%n %u"
@@ -54,15 +54,15 @@ ru:
         separator: "."
         delimiter: " "
         precision: 2
-        
+
     percentage:
       format:
         delimiter: ""
-        
+
     precision:
       format:
         delimiter: ""
-        
+
     human:
       format:
         delimiter: ""
@@ -154,6 +154,13 @@ ru:
 
   activerecord:
     errors:
+      #PaperClip
+      models:
+        document:
+          attributes:
+            doc_file_size:
+              less_than: "%{max}"
+      #end Paperclip
       template:
         header:
           one:   "{{model}}: сохранение не удалось из-за {{count}} ошибки"
@@ -196,18 +203,39 @@ ru:
         odd: "может иметь лишь четное значение"
         even: "может иметь лишь нечетное значение"
         record_invalid: "Возникли ошибки: {{errors}}"
-        
+
       full_messages:
         format: "{{attribute}} {{message}}"
-        
+
 
   support:
     array:
       # Rails 2.2
       sentence_connector: "и"
       skip_last_comma: true
-      
+
       # Rails 2.3
       words_connector: ", "
       two_words_connector: " и "
       last_word_connector: " и "
+  #Paperclip
+  errors:
+    messages:
+      in_between: "должен быть между %{min} и %{max}"
+      spoofed_media_type: "имеет содержимое, не соответствующее заявленному"
+
+  number:
+    human:
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            few: "Байта"
+            many: "Байт"
+            one: "Байт"
+            other: "Байта"
+            gb: "ГБ"
+            kb: "КБ"
+            mb: "МБ"
+            tb: "ТБ"
+  #end Paperclip


### PR DESCRIPTION
## Description

* Increase uploaded documents size limit
* Add file too large error message
* Update locale files to prevent Paperclip's exceptions with errors translations

## Notes

You should be able to test the translation errors fired by Paperclip when editing a user language to be, for example, French, and test uploading a > 10 MB document on an answer.
The interface won't say anything in particular and also won't upload the document or close the upload dialog.