### PR TITLE
Matrix answers api endpoint

### DIFF
--- a/db/migrate/20190506122830_add_api_matrix_answer_options_view.rb
+++ b/db/migrate/20190506122830_add_api_matrix_answer_options_view.rb
@@ -1,0 +1,10 @@
+class AddApiMatrixAnswerOptionsView < ActiveRecord::Migration
+  def up
+    execute 'DROP VIEW IF EXISTS api_matrix_answer_options_view'
+    execute view_sql('20190506122830', 'api_matrix_answer_options_view')
+  end
+
+  def down
+    execute 'DROP VIEW api_matrix_answer_options_view'
+  end
+end

--- a/db/migrate/20190506154821_add_api_matrix_answer_queries_view.rb
+++ b/db/migrate/20190506154821_add_api_matrix_answer_queries_view.rb
@@ -1,0 +1,10 @@
+class AddApiMatrixAnswerQueriesView < ActiveRecord::Migration
+  def up
+    execute 'DROP VIEW IF EXISTS api_matrix_answer_queries_view'
+    execute view_sql('20190506154821', 'api_matrix_answer_queries_view')
+  end
+
+  def down
+    execute 'DROP VIEW api_matrix_answer_queries_view'
+  end
+end

--- a/db/migrate/20190510094856_add_api_matrix_answer_drop_options_view.rb
+++ b/db/migrate/20190510094856_add_api_matrix_answer_drop_options_view.rb
@@ -1,0 +1,10 @@
+class AddApiMatrixAnswerDropOptionsView < ActiveRecord::Migration
+  def up
+    execute 'DROP VIEW IF EXISTS api_matrix_answer_drop_options_view'
+    execute view_sql('20190510094856', 'api_matrix_answer_drop_options_view')
+  end
+
+  def down
+    execute 'DROP VIEW api_matrix_answer_drop_options_view'
+  end
+end

--- a/db/migrate/20190510150637_add_matrix_answers_to_api_answers_view.rb
+++ b/db/migrate/20190510150637_add_matrix_answers_to_api_answers_view.rb
@@ -1,0 +1,11 @@
+class AddMatrixAnswersToApiAnswersView < ActiveRecord::Migration
+  def up
+    execute 'DROP VIEW api_answers_view'
+    execute view_sql('20190510150637', 'api_answers_view')
+  end
+
+  def down
+    execute 'DROP VIEW api_answers_view'
+    execute view_sql('20160203162148', 'api_answers_view')
+  end
+end

--- a/db/migrate/20190513103623_add_matrix_questions_to_questions_views.rb
+++ b/db/migrate/20190513103623_add_matrix_questions_to_questions_views.rb
@@ -1,0 +1,17 @@
+class AddMatrixQuestionsToQuestionsViews < ActiveRecord::Migration
+  def up
+    execute 'DROP VIEW api_questions_tree_view'
+    execute 'DROP VIEW api_questions_view'
+
+    execute view_sql('20190513103623', 'api_questions_view')
+    execute view_sql('20190513103623', 'api_questions_tree_view')
+  end
+
+  def down
+    execute 'DROP VIEW api_questions_tree_view'
+    execute 'DROP VIEW api_questions_view'
+
+    execute view_sql('20151030151237', 'api_questions_view')
+    execute view_sql('20160202174508', 'api_questions_tree_view')
+  end
+end

--- a/db/views/api_answers_view/20190510150637.sql
+++ b/db/views/api_answers_view/20190510150637.sql
@@ -1,0 +1,47 @@
+DROP VIEW IF EXISTS api_answers_view;
+
+CREATE OR REPLACE VIEW api_answers_view AS
+ SELECT answers.id,
+    answers.question_id,
+    answers.user_id,
+    (users.first_name::text || ' '::text) || users.last_name::text AS respondent,
+    answers.looping_identifier,
+    answers.question_answered,
+    ap.field_type_type,
+    ap.field_type_id,
+        CASE
+            WHEN ap.field_type_type::text = 'MultiAnswerOption'::text THEN mao.option_text
+            WHEN ap.field_type_type::text = 'RangeAnswerOption'::text THEN rao.option_text::text
+            ELSE ap.answer_text
+        END AS answer_text,
+        CASE
+          WHEN ap.field_type_type::text = 'MatrixAnswerQuery'::text THEN(
+            SELECT row_to_json(matrix)
+            FROM (
+              SELECT maq.title AS query,
+                     mxao.title AS option,
+                     CASE
+                       WHEN apmo.matrix_answer_drop_option_id IS NOT NULL THEN mado.option_text
+                       ELSE COALESCE(apmo.answer_text, mxao.title)
+                     END AS answer
+            ) AS matrix
+          )
+          ELSE NULL
+          END AS matrix_answer,
+        CASE
+            WHEN ap.field_type_type::text = 'MultiAnswerOption'::text THEN mao.language
+            WHEN ap.field_type_type::text = 'RangeAnswerOption'::text THEN rao.language
+            WHEN ap.field_type_type::text = 'MatrixAnswerQuery'::text THEN maq.language
+            ELSE ''
+        END AS language,
+    ap.details_text,
+    ap.answer_text_in_english
+   FROM answers
+     JOIN answer_parts ap ON ap.answer_id = answers.id
+     JOIN users ON users.id = answers.user_id
+     LEFT JOIN api_multi_answer_options_view mao ON mao.id = ap.field_type_id AND ap.field_type_type::text = 'MultiAnswerOption'::text
+     LEFT JOIN api_range_answer_options_view rao ON rao.id = ap.field_type_id AND ap.field_type_type::text = 'RangeAnswerOption'::text
+     LEFT JOIN answer_part_matrix_options apmo ON apmo.answer_part_id = ap.id AND ap.field_type_type::text = 'MatrixAnswerQuery'::text
+     LEFT JOIN api_matrix_answer_drop_options_view mado ON mado.id = apmo.matrix_answer_drop_option_id
+     LEFT JOIN api_matrix_answer_queries_view maq ON maq.id = ap.field_type_id
+     LEFT JOIN api_matrix_answer_options_view mxao ON apmo.matrix_answer_option_id = mxao.id;

--- a/db/views/api_answers_view/20190510150637.sql
+++ b/db/views/api_answers_view/20190510150637.sql
@@ -42,6 +42,6 @@ CREATE OR REPLACE VIEW api_answers_view AS
      LEFT JOIN api_multi_answer_options_view mao ON mao.id = ap.field_type_id AND ap.field_type_type::text = 'MultiAnswerOption'::text
      LEFT JOIN api_range_answer_options_view rao ON rao.id = ap.field_type_id AND ap.field_type_type::text = 'RangeAnswerOption'::text
      LEFT JOIN answer_part_matrix_options apmo ON apmo.answer_part_id = ap.id AND ap.field_type_type::text = 'MatrixAnswerQuery'::text
-     LEFT JOIN api_matrix_answer_drop_options_view mado ON mado.id = apmo.matrix_answer_drop_option_id
      LEFT JOIN api_matrix_answer_queries_view maq ON maq.id = ap.field_type_id
-     LEFT JOIN api_matrix_answer_options_view mxao ON apmo.matrix_answer_option_id = mxao.id;
+     LEFT JOIN api_matrix_answer_drop_options_view mado ON mado.id = apmo.matrix_answer_drop_option_id AND mado.language = maq.language
+     LEFT JOIN api_matrix_answer_options_view mxao ON apmo.matrix_answer_option_id = mxao.id AND mxao.language = maq.language;

--- a/db/views/api_matrix_answer_drop_options_view/20190510094856.sql
+++ b/db/views/api_matrix_answer_drop_options_view/20190510094856.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE VIEW api_matrix_answer_drop_options_view AS
+  WITH mado_lngs AS(
+    SELECT madof.matrix_answer_drop_option_id,
+           array_agg(upper(madof.language::text)) AS languages
+    FROM matrix_answer_drop_option_fields madof
+    WHERE madof.option_text::text IS NOT NULL
+    GROUP BY madof.matrix_answer_drop_option_id
+  )
+  SELECT mado.id,
+         mado.matrix_answer_id,
+         madof.option_text,
+         upper(madof.language::text) AS language,
+         madof.is_default_language,
+         mado_lngs.languages
+  FROM matrix_answer_drop_options mado
+  JOIN matrix_answer_drop_option_fields madof ON madof.matrix_answer_drop_option_id = mado.id
+  JOIN mado_lngs ON mado_lngs.matrix_answer_drop_option_id = mado.id
+  WHERE madof.option_text::text IS NOT NULL;

--- a/db/views/api_matrix_answer_options_view/20190506122830.sql
+++ b/db/views/api_matrix_answer_options_view/20190506122830.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE VIEW api_matrix_answer_options_view AS
+  WITH mao_lngs AS(
+    SELECT maof.matrix_answer_option_id,
+           array_agg(upper(maof.language::text)) AS languages
+    FROM matrix_answer_option_fields maof
+    WHERE maof.title::text IS NOT NULL
+    GROUP BY maof.matrix_answer_option_id
+  )
+  SELECT mao.id,
+         mao.matrix_answer_id,
+         maof.title,
+         upper(maof.language::text) AS language,
+         maof.is_default_language,
+         mao_lngs.languages
+  FROM matrix_answer_options mao
+  JOIN matrix_answer_option_fields maof ON maof.matrix_answer_option_id = mao.id
+  JOIN mao_lngs ON mao_lngs.matrix_answer_option_id = mao.id
+  WHERE maof.title::text IS NOT NULL;

--- a/db/views/api_matrix_answer_queries_view/20190506154821.sql
+++ b/db/views/api_matrix_answer_queries_view/20190506154821.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE VIEW api_matrix_answer_queries_view AS
+  WITH maq_lngs AS(
+    SELECT maqf.matrix_answer_query_id,
+           array_agg(upper(maqf.language::text)) AS languages
+    FROM matrix_answer_query_fields maqf
+    WHERE maqf.title::text IS NOT NULL
+    GROUP BY maqf.matrix_answer_query_id
+  )
+  SELECT maq.id,
+         maq.matrix_answer_id,
+         maqf.title,
+         upper(maqf.language::text) AS language,
+         maqf.is_default_language,
+         maq_lngs.languages
+  FROM matrix_answer_queries maq
+  JOIN matrix_answer_query_fields maqf ON maqf.matrix_answer_query_id = maq.id
+  JOIN maq_lngs ON maq_lngs.matrix_answer_query_id = maq.id
+  WHERE maqf.title::text IS NOT NULL;

--- a/db/views/api_questions_tree_view/20190513103623.sql
+++ b/db/views/api_questions_tree_view/20190513103623.sql
@@ -1,0 +1,62 @@
+-- DROP VIEW api_questions_tree_view;
+
+CREATE OR REPLACE VIEW api_questions_tree_view AS
+ WITH mao_options AS (
+         SELECT mao.multi_answer_id,
+            mao.language,
+            array_agg(mao.option_text ORDER BY mao.sort_index) AS options
+           FROM api_multi_answer_options_view mao
+          GROUP BY mao.multi_answer_id, mao.language
+        ), rao_options AS (
+         SELECT rao.range_answer_id,
+            rao.language,
+            array_agg(rao.option_text ORDER BY rao.sort_index) AS options
+           FROM api_range_answer_options_view rao
+          GROUP BY rao.range_answer_id, rao.language
+        ), mxao_options AS (
+         SELECT mxao.matrix_answer_id,
+            mxao.language,
+            array_agg(mxao.title) AS options
+           FROM api_matrix_answer_options_view mxao
+           GROUP BY mxao.matrix_answer_id, mxao.language
+        ), mado_options AS (
+         SELECT mado.matrix_answer_id,
+           mado.language,
+           array_agg(mado.option_text) AS options
+           FROM api_matrix_answer_drop_options_view mado
+           GROUP BY mado.matrix_answer_id, mado.language
+        )
+ SELECT q.id,
+    q.section_id,
+    q.answer_type_id,
+    q.answer_type_type,
+    q.is_mandatory,
+    q.language,
+    q.is_default_language,
+    q.title,
+    q.short_title,
+    q.description,
+    q.lft,
+    q.languages,
+    s.questionnaire_id,
+    s.section_type,
+    s.loop_source_id,
+    s.loop_item_type_id,
+    s.looping_section_id,
+    s.depends_on_question_id,
+    s.depends_on_option_id,
+    s.depends_on_option_value,
+    s.is_hidden,
+    s.display_in_tab,
+    s.title AS section_title,
+    s.tab_title AS section_tab_title,
+    s.language AS section_language,
+    s.is_default_language AS section_is_default_language,
+    s.path,
+    COALESCE(mao_options.options, rao_options.options::text[], mado_options.options::text[], mxao_options.options::text[]) AS options
+   FROM api_questions_view q
+     JOIN api_sections_tree_view s ON q.section_id = s.id AND (q.language = s.language OR s.is_default_language AND NOT s.languages @> ARRAY[q.language])
+     LEFT JOIN mao_options ON mao_options.multi_answer_id = q.answer_type_id AND q.answer_type_type = 'MultiAnswer' AND mao_options.language = q.language
+     LEFT JOIN rao_options ON rao_options.range_answer_id = q.answer_type_id AND q.answer_type_type = 'RangeAnswer' AND rao_options.language = q.language
+     LEFT JOIN mxao_options ON mxao_options.matrix_answer_id = q.answer_type_id AND q.answer_type_type = 'MatrixAnswer' AND mxao_options.language = q.language
+     LEFT JOIN mado_options ON mado_options.matrix_answer_id = q.answer_type_id AND q.answer_type_type = 'MatrixAnswer' AND mado_options.language = q.language

--- a/db/views/api_questions_view/20190513103623.sql
+++ b/db/views/api_questions_view/20190513103623.sql
@@ -1,0 +1,27 @@
+-- DROP VIEW api_questions_view;
+
+CREATE OR REPLACE VIEW api_questions_view AS
+ WITH q_lngs AS (
+         SELECT question_fields_1.question_id,
+            array_agg(upper(question_fields_1.language::text)) AS languages
+           FROM question_fields question_fields_1
+          WHERE squish_null(question_fields_1.title) IS NOT NULL
+          GROUP BY question_fields_1.question_id
+        )
+ SELECT questions.id,
+    questions.section_id,
+    questions.answer_type_id,
+    questions.answer_type_type,
+    questions.is_mandatory,
+    upper(question_fields.language::text) AS language,
+    question_fields.is_default_language,
+    strip_tags(question_fields.title) AS title,
+    strip_tags(question_fields.short_title::text) AS short_title,
+    strip_tags(question_fields.description) AS description,
+    qp.lft,
+    q_lngs.languages
+   FROM questions
+     JOIN question_fields ON questions.id = question_fields.question_id
+     JOIN questionnaire_parts qp ON qp.part_type::text = 'Question'::text AND qp.part_id = questions.id
+     JOIN q_lngs ON q_lngs.question_id = questions.id
+  WHERE (questions.answer_type_type::text = ANY (ARRAY['MultiAnswer'::character varying::text, 'RangeAnswer'::character varying::text, 'NumericAnswer'::character varying::text, 'MatrixAnswer'::character varying::text])) AND squish_null(question_fields.title) IS NOT NULL;


### PR DESCRIPTION
## Description

This adds the necessary SQL views to retrieve matrix answers from the database to be then served by the API.

Please refer to the related ORS-API PR in order to have a complete understanding and be able to test as well.

## Notes

Needs `bundle exec rake db:migrate`