### PR TITLE
Add ors api access flag

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -30,6 +30,8 @@ class UsersController < ApplicationController
     if verify_recaptcha(model: @user) && @user.save
       @user.add_or_update_filtering_fields(params[:filtering_field]) if params[:filtering_field]
       url = "http://#{request.host}/"
+      # Revoke access to RAMSAR API by default
+      @user.update_attributes(has_api_access: false) if Rails.root.to_s.include?('ramsar')
       if !current_user
         UserMailer.registration_confirmation(@user, url).deliver
         User.administrators.each do |admin|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -78,7 +78,8 @@ class User < ActiveRecord::Base
   attr_accessible :creator_id, :first_name, :last_name, :language, :email,
     :category, :password, :password_confirmation, :role_ids,
     :single_access_token, :region, :country, :perishable_token,
-    :user_delegates_attributes, :user_delegators_attributes
+    :user_delegates_attributes, :user_delegators_attributes,
+    :has_api_access
 
   accepts_nested_attributes_for :user_delegates, :user_delegators
 

--- a/db/migrate/20190613083927_add_api_acces_flag_to_users.rb
+++ b/db/migrate/20190613083927_add_api_acces_flag_to_users.rb
@@ -1,0 +1,5 @@
+class AddApiAccesFlagToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :has_api_access, :boolean, default: true
+  end
+end


### PR DESCRIPTION
## Description

This is to properly authorize users for API access.
The `single_access_token` is populated by default when a new account is created and cannot be nil.

Adding a flag which states if an user has access to the API will improve how the overall API access is managed; this allows to keep the token in place while having the ability to enable/disable access regardless of that token.

At the moment there's no plan about having the ability to change this flag by the interface, so that has been kept simple.