### PR TITLE
Add reset password link to section delegation email

### DIFF
--- a/app/views/user_mailer/questionnaire_delegated.html.erb
+++ b/app/views/user_mailer/questionnaire_delegated.html.erb
@@ -6,6 +6,7 @@
 
 <p><%= I18n.t('user_mailer.questionnaire_delegated.access') %>  <a href='<%=@url%>/questionnaires/<%=@delegation.questionnaire.id%>/submission'><%=@url%>/questionnaires/<%= @delegation.questionnaire.id %>/submission</a>.</p>
 <p><%= I18n.t('user_mailer.questionnaire_delegated.dashboard') %></p>
+<p><%= I18n.t('user_mailer.password_reset') %> <%= link_to "#{@url}#{new_password_reset_path}", "#{@url}#{new_password_reset_path}" %></p>
 <p>
   <%= I18n.t('user_mailer.greetings')%><br />
   <%= ApplicationProfile.title %>

--- a/app/views/user_mailer/section_delegated.html.erb
+++ b/app/views/user_mailer/section_delegated.html.erb
@@ -14,6 +14,7 @@
 <% end %>
 <p><%= I18n.t('user_mailer.section_delegated.access') %> <a href='<%= @url %>/questionnaires/<%= @delegation_section.section.questionnaire.id %>/submission'><%= @url %>/questionnaires/<%= @delegation_section.section.questionnaire.id %>/submission</a>.</p>
 <p><%= I18n.t('user_mailer.section_delegated.dashboard') %></p>
+<p><%= I18n.t('user_mailer.password_reset') %> <%= link_to "#{@url}#{new_password_reset_path}", "#{@url}#{new_password_reset_path}" %></p>
 <p><%= I18n.t('user_mailer.greetings')%><br />
   <%= ApplicationProfile.title %></p>
 <p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -323,7 +323,7 @@ en:
     new_user_registered: 'New user registered in the system'
     admin_footer: "You have received this e-mail because you are an administrator of the Online Reporting System"
     for_the_user: "for the user"
-    password_reset: "Have your forgotten your credentials to login? Your username is your email. You could also reset your password using this link:"
+    password_reset: "Have you forgotten your credentials to login? Your username is your email. You could also reset your password using this link:"
     delegate_registration:
       subject: "You have been added as a delegate"
     user_registration:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -323,6 +323,7 @@ en:
     new_user_registered: 'New user registered in the system'
     admin_footer: "You have received this e-mail because you are an administrator of the Online Reporting System"
     for_the_user: "for the user"
+    password_reset: "Have your forgotten your credentials to login? Your username is your email. You could also reset your password using this link:"
     delegate_registration:
       subject: "You have been added as a delegate"
     user_registration:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -316,6 +316,7 @@ es:
     new_user_registered: 'Nuevo usuario registrado en el sistema'
     admin_footer: "Ha recibido este correo electrónico porque figura como administrador del Sistema de presentación de informes en línea"
     for_the_user: "para el usuario"
+    password_reset: "¿Ha olvidado sus credenciales para iniciar sesión? Su nombre de usuario es su dirección de correo electrónico. También puede restablecer su contraseña utilizando este enlace:"
     delegate_registration:
       subject: "Se le ha añadido como delegado"
     user_registration:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -318,6 +318,7 @@ fr:
     new_user_registered: 'Nouvel utilisateur enregistré sur le système'
     admin_footer: "Vous avez reçu cet e-mail car vous êtes administrateur du système de rapport en ligne"
     for_the_user: "pour l'utilisateur"
+    password_reset: "Avez-vous oublié vos identifiants pour vous connecter? Votre nom d’utilisateur est votre adresse e-mail. Vous pouvez réinitialiser votre mot de passe en suivant ce lien:"
     delegate_registration:
       subject: "Vous avez été ajouté en tant que délégué"
     user_registration:


### PR DESCRIPTION
## Description

Add text to automated delegations emails related to password reset.

## Notes

Related codebase ticket [here](https://unep-wcmc.codebasehq.com/projects/ors-maintainance/tickets/3)