### PR TITLE
Remove html tags from interface

### DIFF
--- a/app/views/delegation_sections/new.html.erb
+++ b/app/views/delegation_sections/new.html.erb
@@ -14,7 +14,7 @@
         <ol>
           <li>
             <%= label_tag t('delegate_section.available_sections') %>
-            <%= select "delegation_section", "section_id", @available_sections.collect{|p| [('-'*p.level) + OrtSanitize.white_space_cleanse((p.tab_title(I18n.locale.to_s).present? ? p.tab_title(I18n.locale.to_s) : p.title(I18n.locale.to_s)))[0,55] , p.id] }, { :include_blank => t('delegate_dashboard.please_select_s') } %>
+            <%= select "delegation_section", "section_id", @available_sections.collect{|p| [('-'*p.level) + OrtSanitize.white_space_cleanse((p.tab_title(I18n.locale.to_s).present? ? strip_tags(p.tab_title(I18n.locale.to_s)) : strip_tags(p.title(I18n.locale.to_s))))[0,55] , p.id] }, { :include_blank => t('delegate_dashboard.please_select_s') } %>
           </li>
           <li id="item_names" style="display: none">
             <p style="color:blue"><%= t('delegate_section.looping_section_w') %></p>

--- a/app/views/delegations/_delegation_details.html.erb
+++ b/app/views/delegations/_delegation_details.html.erb
@@ -13,8 +13,8 @@
           <tbody>
           <% @delegation.delegation_sections.each do |delegation_section| %>
               <tr>
-                <td><%= OrtSanitize.white_space_cleanse(delegation_section.section.value_in((delegation_section.section.root? ? :tab_title : :title), @authorization[:language])) %></td>
-                <td><%= OrtSanitize.white_space_cleanse(delegation_section.section.root.value_in(:tab_title, @authorization[:language])) %></td>
+                <td><%= strip_tags(OrtSanitize.white_space_cleanse(delegation_section.section.value_in((delegation_section.section.root? ? :tab_title : :title), @authorization[:language]))) %></td>
+                <td><%= strip_tags(OrtSanitize.white_space_cleanse(delegation_section.section.root.value_in(:tab_title, @authorization[:language]))) %></td>
                 <td><%= delegation_section.loop_item_names.map{|loop_item_name| h(loop_item_name.item_name(@authorization[:language]))}.join(', ') %></td>
               </tr>
           <% end -%>

--- a/app/views/delegations/show.html.erb
+++ b/app/views/delegations/show.html.erb
@@ -38,8 +38,8 @@
             <tbody>
             <% @delegation.delegation_sections.each do |delegation_section| -%>
                 <tr>
-                  <td><%= delegation_section.section.present? ? OrtSanitize.white_space_cleanse(delegation_section.section.title(I18n.locale.to_s)) : "-" %></td>
-                  <td><%= delegation_section.section && delegation_section.section.root.present? ? OrtSanitize.white_space_cleanse(delegation_section.section.root.title(I18n.locale.to_s)) : "-"%></td>
+                  <td><%= delegation_section.section.present? ? strip_tags(OrtSanitize.white_space_cleanse(delegation_section.section.title(I18n.locale.to_s))) : "-" %></td>
+                  <td><%= delegation_section.section && delegation_section.section.root.present? ? strip_tags(OrtSanitize.white_space_cleanse(delegation_section.section.root.title(I18n.locale.to_s))) : "-"%></td>
                   <td>
                     <%= delegation_section.loop_item_names.map{|loop_item_name| h(loop_item_name.item_name(I18n.locale.to_s))}.join(', ') -%>
                   </td>

--- a/app/views/user_delegates/dashboard.html.erb
+++ b/app/views/user_delegates/dashboard.html.erb
@@ -38,8 +38,8 @@
                 <tbody>
                   <% delegation.delegation_sections.each do |delegation_section| -%>
                     <tr>
-                      <td><%= OrtSanitize.white_space_cleanse(delegation_section.section.value_in((delegation_section.section.root? ? :tab_title : :title), current_user.language)) %></td>
-                      <td><%= OrtSanitize.white_space_cleanse(delegation_section.section.root.value_in(:tab_title, current_user.language))%></td>
+                      <td><%= strip_tags(OrtSanitize.white_space_cleanse(delegation_section.section.value_in((delegation_section.section.root? ? :tab_title : :title), current_user.language))) %></td>
+                      <td><%= strip_tags(OrtSanitize.white_space_cleanse(delegation_section.section.root.value_in(:tab_title, current_user.language)))%></td>
                       <td><%= delegation_section.loop_item_names.map{|loop_item_name| h(loop_item_name.item_name(current_user.language))}.join(', ') %></td>
                     </tr>
                   <% end -%>


### PR DESCRIPTION
## Description

Remove html tags from sections titles so that are not showing on the interface.

## Notes

Related codebase ticket [here](https://unep-wcmc.codebasehq.com/projects/ors-maintainance/tickets/2).