### PR TITLE
Make sure the respondent_id param is present

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -38,7 +38,7 @@ class AnswersController < ApplicationController
     @authorization = current_user ? current_user.authorization_for(@question, @current_user_delegate.try(:id)) : false
     raise CanCan::AccessDenied.new(t("flash_messages.#{@authorization ? @authorization[:error_message] : "not_authorized"}")) if !@authorization || @authorization[:error_message]
     I18n.locale = @authorization[:language]
-    user_id = params[:respondent_id] || @authorization[:user].id
+    user_id = params[:respondent_id].presence || @authorization[:user].id
     from_dependent_section, _ = @question.nested_under_dependent_section?
     # Use custom find_or_create method to make sure to fetch the correct answer and
     # not create new ones
@@ -54,7 +54,7 @@ class AnswersController < ApplicationController
     @authorization = current_user ? current_user.authorization_for(@question, @current_user_delegate.try(:id)) : false
     raise CanCan::AccessDenied.new(t("flash_messages.#{@authorization ? @authorization[:error_message] : "not_authorized"}")) if !@authorization || @authorization[:error_message]
     I18n.locale = @authorization[:language]
-    user_id = params[:respondent_id] || @authorization[:user].id
+    user_id = params[:respondent_id].presence || @authorization[:user].id
     from_dependent_section, _ = @question.nested_under_dependent_section?
     # Use custom find_or_create method to make sure to fetch the correct answer and
     # not create new ones


### PR DESCRIPTION
[Codebase](https://unep-wcmc.codebasehq.com/projects/ors-maintainance/tickets/5) ticket

Looks like the call at the `add_document` method in the AnswersController has got the param `respondent_id` in it, but his value is blank, and the way this was implemented wasn't checking this case.
Specifically, the line 41
`@answer = Answer.find_or_create_new_answer(@question, User.find(user_id), @question.section.root.questionnaire, from_dependent_section, params[:looping_identifier])
` was throwing the error for it couldn't find a User with id = blank.
The same for the `add_links` method below (line 61)