### PR TITLE
Show questionnaire table only if associated with users on show page

### DIFF
--- a/app/views/user_delegates/_delegated_tasks_table.html.erb
+++ b/app/views/user_delegates/_delegated_tasks_table.html.erb
@@ -9,7 +9,7 @@
   <tbody>
     <% @user_delegate.delegations.each do |delegation| %>
       <tr>
-        <td><%= link_to h(delegation.questionnaire.title), submission_questionnaire_path(delegation.questionnaire, user_delegate: @user_delegate.id) %></td>
+        <td><%= link_to h(delegation.questionnaire.title), submission_questionnaire_path(delegation.questionnaire, user_delegate: @user_delegate.id) if delegation.questionnaire.try(:title).present? %></td>
         <td><%=h delegation.remarks %></td>
         <td>
           <%= link_to "Edit", edit_delegation_path(delegation) %> | <%= link_to t('generic.manage'), delegation_path(delegation) %> | <%= link_to t('generic.remove'), delegation, :method => :delete, :confirm => t('generic.are_you_sure') %>

--- a/app/views/users/_existing_delegations.html.erb
+++ b/app/views/users/_existing_delegations.html.erb
@@ -19,7 +19,7 @@
         <% @user.delegated_tasks.each do |delegation| %>
             <tr id="row_<%=delegation.id.to_s%>">
               <td><%= link_to h(delegation.user.full_name), user_path(delegation.user) %></td>
-              <td><%= delegation.questionnaire.title %></td>
+              <td><%= delegation.questionnaire.try(:title) %></td>
               <td><%= link_to t('manage'), user_delegate_path(delegation.user_delegate) %></td>
             </tr>
         <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -48,11 +48,11 @@
     </tbody>
   </table>
 
-  <div class="mt-1">
-    <a style="font-weight:600; font-size:14px" id="toggle_help" href="#">
-      Filtering fields
-    </a>
-    <div id="help_div" style="display: none" class="mt-1">
+  <div class="respondents-list-delegations">
+    <div class="page-header">
+      <h2> Filtering fields </h2>
+    </div>
+    <div id="help_div" >
         <table class="user_table">
           <% unless @user.available_questionnaires.empty? %>
           <thead>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -47,61 +47,53 @@
       <% end %>
     </tbody>
   </table>
-  <!--
-    <%# @user.available_questionnaires.each do |questionnaire| -%>
-      <%# questionnaire.filtering_fields.each do |field| -%>
-        <p><strong><%#= "#{h(field.name)} #{info_tip "Questionnaire", questionnaire.title}"%>: </strong> <%#= @user.get_filtering_field_value(field) %></p>
-        <%# end -%>
-        <%# end -%>
 
-  -->
   <div class="mt-1">
     <a style="font-weight:600; font-size:14px" id="toggle_help" href="#">
       Filtering fields
     </a>
     <div id="help_div" style="display: none" class="mt-1">
-      <table class="user_table">
-        <thead>
-          <tr>
-            <th><%= t("generic.questionnaire") %></th>
-            <th><%= t("generic.filtering_fields") %></th>
-            <th><%= t("generic.value") %></th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @user.available_questionnaires.each do |questionnaire| -%>
-            <% questionnaire.filtering_fields.each do |field| -%>
-              <tr>
-                <td><%= questionnaire.title%></td>
-                <td><%= h(field.name)%></td>
-                <td><%= @user.get_filtering_field_value(field) %></td>
-              </tr>
-            <% end -%>
-          <% end -%>
-        </tbody>
-      </table>
+        <table class="user_table">
+          <% unless @user.available_questionnaires.empty? %>
+          <thead>
+            <tr>
+              <th><%= t("generic.questionnaire") %></th>
+              <th><%= t("generic.filtering_fields") %></th>
+              <th><%= t("generic.value") %></th>
+            </tr>
+          </thead>
+          <tbody>
+              <% @user.available_questionnaires.each do |questionnaire| -%>
+                <% questionnaire.filtering_fields.each do |field| -%>
+                  <tr>
+                    <td><%= questionnaire.title%></td>
+                    <td><%= h(field.name)%></td>
+                    <td><%= @user.get_filtering_field_value(field) %></td>
+                  </tr>
+                <% end -%>
+              <% end -%>
+            <% else %>
+              <tr><%= "No available questionnaires" %></tr>
+          </tbody>
+          <% end %>
+        </table>
     </div>
   </div>
 
   <% unless @user.available_questionnaires.empty? %>
-    <hr />
     <div class="span-24 last" id="questionnaires">
       <%= render :partial => "home/submission", :locals => {
         :questionnaires => @user.available_questionnaires } %>
-  </div><!-- /questionnaires -->
-<% end %>
-
-<% if @user.is_delegate? %>
-  <div class='respondents-list-delegations'>
-    <div class="page-header">
-      <h2>Delegations</h2>
     </div>
-    <%= render 'existing_delegations' %>
-  </div>
-<% end %>
+  <% end %>
+
+  <% if @user.is_delegate? %>
+    <div class='respondents-list-delegations'>
+      <div class="page-header">
+        <h2>Delegations</h2>
+      </div>
+      <%= render 'existing_delegations' %>
+    </div>
+  <% end %>
 
 </div>
-
-
-
-</div><!-- /content -->


### PR DESCRIPTION
This is to prevent errors when trying to edit a user with no questionnaire associated. 

Related [codebase ticket](https://unep-wcmc.codebasehq.com/projects/ors-maintainance/tickets/6)