### PR TITLE
Fix/matrix options queries order

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -52,7 +52,7 @@ class Question < ActiveRecord::Base
   #create the question's answer_type or use the section answer type
   def self.create_question_answer_type params
     if params[:answer_type]
-      answer_type = params[:part][:answer_type_type].classify.constantize.new(params[:answer_type])
+      answer_type = params[:part][:answer_type_type].classify.constantize.new(sorted_params(params))
       if answer_type.save
         answer_type
       end
@@ -64,7 +64,7 @@ class Question < ActiveRecord::Base
   def update_answer_type params
     if params[:part][:answer_type_type] == self.answer_type_type
       #if the answer type is the same, just update the answer_type attributes
-      self.answer_type.update_attributes!(params[:answer_type])
+      self.answer_type.update_attributes!(self.class.sorted_params(params))
     else
       if self.answers.present? #changing a question's answer_type will cause any existing answers to that question to be removed
         self.remove_submission_elements!
@@ -75,7 +75,7 @@ class Question < ActiveRecord::Base
       end
       #create thew new answer type based on the params (if they exist. For questions of "same answer type" sections, it doesn't exist.
       if params[:part][:answer_type_type]
-        self.answer_type = params[:part][:answer_type_type].classify.constantize.new(params[:answer_type])
+        self.answer_type = params[:part][:answer_type_type].classify.constantize.new(self.class.sorted_params(params))
         self.answer_type.save!
       end
     end
@@ -251,6 +251,17 @@ class Question < ActiveRecord::Base
       reload
       self.question_extras_ids = nil
     end
+  end
+
+  def self.sorted_params(params)
+    attrs = params[:answer_type]
+
+    attrs[:matrix_answer_queries_attributes] =
+      attrs[:matrix_answer_queries_attributes].sort_by { |k,_| k }.to_h
+    attrs[:matrix_answer_options_attributes] =
+      attrs[:matrix_answer_options_attributes].sort_by { |k,_| k }.to_h
+
+    attrs
   end
 end
 

--- a/app/views/matrix_answers/_form.html.erb
+++ b/app/views/matrix_answers/_form.html.erb
@@ -71,7 +71,7 @@
 
         <% else -%>
             <% j = 0 %>
-                <% matrix_answer_queries =  type.matrix_answer_queries.order('id DESC') %>
+                <% matrix_answer_queries =  type.matrix_answer_queries.order('id ASC') %>
                 var queriesData = [
                     <% matrix_answer_queries.each_index do |i| %>
                         {
@@ -89,7 +89,7 @@
                     <% end -%>
                 ];
             <% j = 0 %>
-                <% matrix_answer_options =  type.matrix_answer_options.order('id DESC') %>
+                <% matrix_answer_options =  type.matrix_answer_options.order('id ASC') %>
                 var optionsData = [
                     <% matrix_answer_options.each_index do |i| %>
                         {

--- a/app/views/matrix_answers/_preview.html.erb
+++ b/app/views/matrix_answers/_preview.html.erb
@@ -1,12 +1,12 @@
 <% queries_as_rows = answer_type.matrix_orientation == 0 %>
-<% columns = (queries_as_rows ? answer_type.matrix_answer_options : answer_type.matrix_answer_queries).order('id DESC')  -%>
-<% rows = (queries_as_rows ? answer_type.matrix_answer_queries : answer_type.matrix_answer_options).order('id DESC')  -%>
+<% columns = (queries_as_rows ? answer_type.matrix_answer_options : answer_type.matrix_answer_queries) -%>
+<% rows = (queries_as_rows ? answer_type.matrix_answer_queries : answer_type.matrix_answer_options) -%>
 <% the_id = "matrix_answer_#{answer_type.id}"-%>
 <table class="submission_matrix" style="width: 550px">
   <thead>
   <tr>
     <th></th>
-    <% columns.each do |column| -%>
+    <% columns.order('id ASC').each do |column| -%>
         <th>
           <%=h column.title %>
         </th>
@@ -14,7 +14,7 @@
   </tr>
   </thead>
   <tbody>
-  <% rows.each do |row| %>
+  <% rows.order('id ASC').each do |row| %>
       <tr>
         <td class="matrix_queries"><%=h row.title %></td>
         <% columns.each do |column| %>

--- a/app/views/matrix_answers/_show.html.erb
+++ b/app/views/matrix_answers/_show.html.erb
@@ -9,7 +9,7 @@
 </p>
 <p>Queries</p>
 <ul>
-  <% answer_type.matrix_answer_queries.order('id DESC').each do |query| %>
+  <% answer_type.matrix_answer_queries.order('id ASC').each do |query| %>
       <li>
         <%= h query.title(language) %>
       </li>
@@ -17,7 +17,7 @@
 </ul>
 <p>Options</p>
 <ul>
-  <% answer_type.matrix_answer_options.order('id DESC').each do |option| %>
+  <% answer_type.matrix_answer_options.order('id ASC').each do |option| %>
       <li>
         <%= h option.title(language) %>
       </li>

--- a/app/views/matrix_answers/_submission.html.erb
+++ b/app/views/matrix_answers/_submission.html.erb
@@ -1,6 +1,6 @@
 <% queries_as_rows = answer_type.matrix_orientation == 0 %>
-<% columns = queries_as_rows ? answer_type.matrix_answer_options.order('id DESC') : answer_type.matrix_answer_queries  -%>
-<% rows = queries_as_rows ? answer_type.matrix_answer_queries : answer_type.matrix_answer_options.order('id DESC')  -%>
+<% columns = queries_as_rows ? answer_type.matrix_answer_options : answer_type.matrix_answer_queries  -%>
+<% rows = queries_as_rows ? answer_type.matrix_answer_queries : answer_type.matrix_answer_options  -%>
 <% drop_down_options = answer_type.matrix_answer_drop_options.order('id DESC') %>
 <% selection = {} %>
 <% if answer
@@ -13,7 +13,7 @@ end %>
     <thead>
     <tr>
       <th></th>
-      <% columns.each do |column| -%>
+      <% columns.order('id DESC').each do |column| -%>
           <th>
             <%=h @fields[(column.class.to_s.underscore.downcase+"_field").to_sym][column.id.to_s] %>
           </th>
@@ -21,7 +21,7 @@ end %>
     </tr>
     </thead>
     <tbody>
-    <% rows.each do |row| %>
+    <% rows.order('id DESC').each do |row| %>
         <tr>
           <td class="matrix-queries"><%=h @fields[(row.class.to_s.underscore.downcase+"_field").to_sym][row.id.to_s] %></td>
           <%= render :partial => "matrix_answers/#{answer_type.display_reply_humanize.gsub(" ", "_").tableize}", :locals => { :columns => columns, :answer => answer, :the_id => the_id, :row_id => row.id.to_s, :queries_as_rows => queries_as_rows, :selection => selection, :drop_down_options => drop_down_options, :disabled => disabled } %>

--- a/app/views/matrix_answers/_submission.html.erb
+++ b/app/views/matrix_answers/_submission.html.erb
@@ -13,7 +13,7 @@ end %>
     <thead>
     <tr>
       <th></th>
-      <% columns.order('id DESC').each do |column| -%>
+      <% columns.order('id ASC').each do |column| -%>
           <th>
             <%=h @fields[(column.class.to_s.underscore.downcase+"_field").to_sym][column.id.to_s] %>
           </th>
@@ -21,7 +21,7 @@ end %>
     </tr>
     </thead>
     <tbody>
-    <% rows.order('id DESC').each do |row| %>
+    <% rows.order('id ASC').each do |row| %>
         <tr>
           <td class="matrix-queries"><%=h @fields[(row.class.to_s.underscore.downcase+"_field").to_sym][row.id.to_s] %></td>
           <%= render :partial => "matrix_answers/#{answer_type.display_reply_humanize.gsub(" ", "_").tableize}", :locals => { :columns => columns, :answer => answer, :the_id => the_id, :row_id => row.id.to_s, :queries_as_rows => queries_as_rows, :selection => selection, :drop_down_options => drop_down_options, :disabled => disabled } %>


### PR DESCRIPTION
## Description

Hope this finally fixes the weird ordering issues related to matrix queries and options!

Unfortunately it's not really the kind of fix I wished to apply, but that was the only way (and less painful way?) I found to make it work.
The changes applied are related to sorting the params as they come in from the form, which are being returned in reversed order for some reason; this means that the first option or query created was the one saved the last (so higher ID) resulting in all sorts of issues when adding more queries or options at a later stage (update).
So the items are now also ordered in ascending order (first created first served so to say)

## Notes
[Codebase ticket](https://unep-wcmc.codebasehq.com/projects/ors-maintainance/tickets/12)