### PR TITLE
Generate pdf also when inactive

### DIFF
--- a/app/reports/questionnaire_pdf.rb
+++ b/app/reports/questionnaire_pdf.rb
@@ -34,7 +34,7 @@ class QuestionnairePdf < Prawn::Document
     ap_logo = ap && ap.logo && ap.logo.path
     fallback_logo = Dir.glob("public/assets/logos/#{current_instance.split('-').first}*", File::FNM_CASEFOLD).first
     logo = ap_logo || "#{Rails.root}/#{fallback_logo}"
-    image logo, position: :right, width: 150 if logo
+    image logo, position: :right, width: 150 if logo && File.exist?(logo)
     text "#{current_instance.upcase}", size: 14, style: :bold
 
     move_down 10

--- a/app/workers/pdf_generator.rb
+++ b/app/workers/pdf_generator.rb
@@ -7,9 +7,7 @@ class PdfGenerator
       user = User.find(user_id)
       questionnaire = Questionnaire.find(questionnaire_id)
       requester = requester_id == user_id ? user : User.find(requester_id)
-      if requester.role?(:admin) || questionnaire.status != QuestionnaireStatus::INACTIVE
-        QuestionnairePdf.new.to_pdf requester, user, questionnaire, url_prefix, short_version
-      end
+      QuestionnairePdf.new.to_pdf requester, user, questionnaire, url_prefix, short_version
     rescue => e
       Appsignal.add_exception(e)
     end


### PR DESCRIPTION
## Description

* Allow any user to generate PDF report of questionnaires regardless the status of the questionnaire (active, inactive or closed)
* Keep generating the PDF report regardless if logo file is found or not