### PR TITLE
update mimemagic and scrypt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,10 @@ source 'https://rubygems.org'
 
 gem 'rails', '3.2.22'
 gem 'rake', '10.0.3'
+# The previous version of mimemagic was pulled on 20/03/21 
+# and licensing changed to GPL2.
+# 0.3.10 seems to hit issues with axlsx
+gem 'mimemagic', '0.3.9'
 
 gem 'pg'
 gem 'foreigner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,7 +166,7 @@ GEM
     faker (1.6.6)
       i18n (~> 0.5)
     fastercsv (1.5.5)
-    ffi (1.9.17)
+    ffi (1.12.2)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
@@ -205,7 +205,9 @@ GEM
       treetop (~> 1.4.8)
     metaclass (0.0.4)
     mime-types (1.25.1)
-    mimemagic (0.3.2)
+    mimemagic (0.3.9)
+      nokogiri (~> 1)
+      rake
     mini_portile2 (2.1.0)
     minitest (4.7.5)
     minitest-rails (1.0.1)
@@ -307,9 +309,8 @@ GEM
       railties (~> 3.2.0)
       sass (>= 3.1.10)
       tilt (~> 1.3)
-    scrypt (3.0.3)
-      ffi-compiler (>= 1.0.0)
-      rake
+    scrypt (3.0.7)
+      ffi-compiler (>= 1.0, < 2.0)
     select2-rails (4.0.0)
       thor (~> 0.14)
     sexy_relations (1.0.4)
@@ -402,6 +403,7 @@ DEPENDENCIES
   jquery-ui-rails (= 2.0.1)
   json
   jstree-rails!
+  mimemagic (= 0.3.9)
   minitest-rails (~> 1.0)
   mocha
   newrelic_rpm
@@ -435,4 +437,4 @@ DEPENDENCIES
   uglifier
 
 BUNDLED WITH
-   1.16.1
+   1.17.3


### PR DESCRIPTION
# The previous version of mimemagic was pulled on 20/03/21 
# and licensing changed to GPL2.

scrypt 3.0.3 gave this error:

`ld: symbol(s) not found for architecture i386`

It happens when installing ORS gems (scrypt specifically). Looks like I need to install an earlier version of Xcode, but no idea if that will cause problems elsewhere...

The macOS 10.14 SDK no longer contains support for compiling 32-bit applications. If developers need to compile for i386, Xcode 9.4 or earlier is required. [Release notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-10-release-notes)

scrypt 3.0.7 seems to be fine.