### PR TITLE
Notify all admins when questionnaire is submitted

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'jquery-ui-rails', '2.0.1'
 gem 'jqgrid-jquery-rails', '~> 4.4.001'
 gem 'tinymce-rails', '4.0'
 gem 'tinymce-rails-langs', '~>4.2'
-gem 'jstree-rails', :git => 'https://github.com/tristanm/jstree-rails.git'
+gem 'jstree-rails', :git => 'git://github.com/tristanm/jstree-rails.git'
 gem "gritter", "1.1.0"
 gem 'tooltipster-rails', '~> 3.2.6'
 gem 'jquery-tablesorter', '~> 1.16.3'

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'jquery-ui-rails', '2.0.1'
 gem 'jqgrid-jquery-rails', '~> 4.4.001'
 gem 'tinymce-rails', '4.0'
 gem 'tinymce-rails-langs', '~>4.2'
-gem 'jstree-rails', :git => 'git://github.com/tristanm/jstree-rails.git'
+gem 'jstree-rails', :git => 'https://github.com/tristanm/jstree-rails.git'
 gem "gritter", "1.1.0"
 gem 'tooltipster-rails', '~> 3.2.6'
 gem 'jquery-tablesorter', '~> 1.16.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: git://github.com/tristanm/jstree-rails.git
+  revision: e2ad211ea7835a1811e66c3d4ef1e21bfbe6e27d
+  specs:
+    jstree-rails (0.0.1)
+      rails (>= 3.1)
+
+GIT
   remote: https://github.com/randym/axlsx
   revision: 64038e6af1db608daae2aad49874071070285eac
   branch: release-3.0.0
@@ -8,13 +15,6 @@ GIT
       mimemagic (~> 0.3)
       nokogiri (>= 1.7.1)
       rubyzip (~> 1.2, >= 1.2.1)
-
-GIT
-  remote: https://github.com/tristanm/jstree-rails.git
-  revision: 66fbbb9ffc4ce8963cbd1717ef100864e7c5df1d
-  specs:
-    jstree-rails (0.0.1)
-      rails (>= 3.1)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,4 @@
 GIT
-  remote: git://github.com/tristanm/jstree-rails.git
-  revision: e2ad211ea7835a1811e66c3d4ef1e21bfbe6e27d
-  specs:
-    jstree-rails (0.0.1)
-      rails (>= 3.1)
-
-GIT
   remote: https://github.com/randym/axlsx
   revision: 64038e6af1db608daae2aad49874071070285eac
   branch: release-3.0.0
@@ -15,6 +8,13 @@ GIT
       mimemagic (~> 0.3)
       nokogiri (>= 1.7.1)
       rubyzip (~> 1.2, >= 1.2.1)
+
+GIT
+  remote: https://github.com/tristanm/jstree-rails.git
+  revision: 66fbbb9ffc4ce8963cbd1717ef100864e7c5df1d
+  specs:
+    jstree-rails (0.0.1)
+      rails (>= 3.1)
 
 GEM
   remote: https://rubygems.org/

--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -287,7 +287,7 @@ class QuestionnairesController < ApplicationController
       if @authorized_submitter.save!
         if Rails.env == 'production'
           UserMailer.questionnaire_submitted(current_user, @questionnaire).deliver
-          UserMailer.admin_notification_questionnaire_submitted(current_user, @questionnaire).deliver
+          notify_admins
         end
       end
       flash[:notice] = t('s_details.submission_success') if !flash[:error]
@@ -513,6 +513,13 @@ class QuestionnairesController < ApplicationController
   def check_delegate_authorisation
     if params[:user_delegate] && ( !UserDelegate.find_by_id(params[:user_delegate]) || !current_user.authorized_to_answer?(@questionnaire, params[:user_delegate]) )
       raise CanCan::AccessDenied.new(t('flash_messages.not_authorized'))
+    end
+  end
+
+  def notify_admins
+    admins = User.administrators
+    admins.each do |admin|
+      UserMailer.notify_admins_questionnaire_submitted(current_user, admin, @questionnaire).deliver
     end
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -54,17 +54,6 @@ class UserMailer < ActionMailer::Base
     )
   end
 
-  def admin_notification_questionnaire_submitted(user, questionnaire)
-    admin = questionnaire.user
-    I18n.locale = admin.language
-    @user = user
-    @questionnaire = questionnaire
-    mail(
-      to: admin.email,
-      subject: (questionnaire.email_subject(user.language) ? questionnaire.email_subject(user.language) + " - " : "") + I18n.t('user_mailer.questionnaire_submitted.admin_subject') + " " + user.full_name
-    )
-  end
-
   def notify_admins_questionnaire_submitted(user, admin, questionnaire)
     I18n.locale = admin.language
     @user = user

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -65,6 +65,16 @@ class UserMailer < ActionMailer::Base
     )
   end
 
+  def notify_admins_questionnaire_submitted(user, admin, questionnaire)
+    I18n.locale = admin.language
+    @user = user
+    @questionnaire = questionnaire
+    mail(
+      to: admin.email,
+      subject: (questionnaire.email_subject(user.language) ? questionnaire.email_subject(user.language) + " - " : "") + I18n.t('user_mailer.questionnaire_submitted.admin_subject') + " " + user.full_name
+    )
+  end
+
   def request_unsubmission(user, questionnaire, subject, msg, url)
     admin = questionnaire.user
     I18n.locale = admin.language

--- a/app/views/user_mailer/admin_notification_questionnaire_submitted.html.erb
+++ b/app/views/user_mailer/admin_notification_questionnaire_submitted.html.erb
@@ -1,2 +1,0 @@
-<p><%=t('user_mailer.questionnaire_submitted.admin_line', :user => h(@user.full_name), :questionnaire => @questionnaire.title(@questionnaire.user.language)).html_safe %></p>
-<p>---------------- <br /><%=t('user_mailer.admin_footer')%>

--- a/app/views/user_mailer/notify_admins_questionnaire_submitted.html.erb
+++ b/app/views/user_mailer/notify_admins_questionnaire_submitted.html.erb
@@ -1,0 +1,2 @@
+<p><%=t('user_mailer.questionnaire_submitted.admin_line', :user => h(@user.full_name), :questionnaire => @questionnaire.title(@questionnaire.user.language)).html_safe %></p>
+<p>---------------- <br /><%=t('user_mailer.admin_footer')%>


### PR DESCRIPTION
[36](https://unep-wcmc.codebasehq.com/projects/ors-maintainance/tickets/36)

Right now when a respondent submits the questionnaire notification is sent only to the admin user who created the questionnaire. This need to be changed so that all admins receive notification when submitted.